### PR TITLE
Move setArea call outside of construct to avoid LocalizedException is…

### DIFF
--- a/Console/Command/SyncProducts.php
+++ b/Console/Command/SyncProducts.php
@@ -95,7 +95,6 @@ class SyncProducts extends Command
         NostoHelperData\Proxy $nostoHelperData
 
     ) {
-        $state->setAreaCode(Area::AREA_FRONTEND);
         parent::__construct();
 
         $this->productCollectionFactory = $productCollectionFactory;
@@ -137,6 +136,10 @@ class SyncProducts extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!$this->state->getAreaCode()) {
+            $this->state->setAreaCode(Area::AREA_FRONTEND);
+        }
+
         if ($this->moduleManager->isEnabled(NostoHelperData::MODULE_NAME)) {
             $limit = (int)$input->getOption('batch');
 


### PR DESCRIPTION
Moving the setArea outside of the construct avoids conflict with other CLI commands the need to setArea.  Closes #96 