### PR TITLE
Fix infinite redirect loop on Magento EE 2.1.4

### DIFF
--- a/Block/Adminhtml/Account/Iframe.php
+++ b/Block/Adminhtml/Account/Iframe.php
@@ -125,7 +125,7 @@ class Iframe extends BlockTemplate
             $this->backendAuthSession->setData('nosto_message', null);
         }
 
-        $store = $this->getSelectedStore();
+        $store = $this->nostoHelperScope->getSelectedStore($this->getRequest());
         $account = $this->nostoHelperAccount->findAccount($store);
         return IframeHelper::getUrl(
             $this->nostoIframeMetaBuilder->build($store),
@@ -136,30 +136,6 @@ class Iframe extends BlockTemplate
     }
 
     /**
-     * Returns the currently selected store.
-     * Nosto can only be configured on a store basis, and if we cannot find a
-     * store, an exception is thrown.
-     *
-     * @return Store the store.
-     * @throws NotFoundException store not found.
-     */
-    public function getSelectedStore()
-    {
-        $store = null;
-        if ($this->nostoHelperScope->isSingleStoreMode()) {
-            $store = $this->nostoHelperScope->getStore(true);
-        } elseif (($storeId = $this->_request->getParam('store'))) {
-            $store = $this->nostoHelperScope->getStore($storeId);
-        } elseif (($this->nostoHelperScope->getStore())) {
-            $store = $this->nostoHelperScope->getStore();
-        } else {
-            throw new NotFoundException(__('Store not found.'));
-        }
-
-        return $store;
-    }
-
-    /**
      * Returns the config for the Nosto iframe JS component.
      * This config can be converted into JSON in the view file.
      *
@@ -167,10 +143,9 @@ class Iframe extends BlockTemplate
      */
     public function getIframeConfig()
     {
-        $get = [
-            'store' => $this->getSelectedStore()->getId(),
-            'isAjax' => true
-        ];
+        $store = $this->nostoHelperScope->getSelectedStore($this->getRequest());
+        $get = ['store' => $store->getId(), 'isAjax' => true];
+
         return [
             'iframe_handler' => [
                 'origin' => $this->getIframeOrigin(),

--- a/Controller/Adminhtml/Account/Index.php
+++ b/Controller/Adminhtml/Account/Index.php
@@ -69,7 +69,9 @@ class Index extends Base
      */
     public function execute()
     {
-        if (!$this->nostoHelperScope->getSelectedStore($this->getRequest())) {
+        $store = $this->nostoHelperScope->getSelectedStore($this->getRequest());
+
+        if (!($store && $store->getId())) {
             // If we are not under a store view, then redirect to the first
             // found one. Nosto is configured per store.
             foreach ($this->nostoHelperScope->getWebsites() as $website) {

--- a/Controller/Adminhtml/Account/Index.php
+++ b/Controller/Adminhtml/Account/Index.php
@@ -39,9 +39,7 @@ namespace Nosto\Tagging\Controller\Adminhtml\Account;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Page;
 use Magento\Framework\Controller\Result\Redirect;
-use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\View\Result\PageFactory;
-use Magento\Store\Api\Data\StoreInterface;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 
 class Index extends Base
@@ -71,7 +69,7 @@ class Index extends Base
      */
     public function execute()
     {
-        if (!$this->getSelectedStore()) {
+        if (!$this->nostoHelperScope->getSelectedStore($this->getRequest())) {
             // If we are not under a store view, then redirect to the first
             // found one. Nosto is configured per store.
             foreach ($this->nostoHelperScope->getWebsites() as $website) {
@@ -91,30 +89,5 @@ class Index extends Base
         }
 
         return $result;
-    }
-
-    /**
-     * Returns the currently selected store.
-     * If it is single store setup, then just return the default store.
-     * If it is a multi store setup, the expect a store id to passed in the
-     * request params and return that store as the current one.
-     *
-     * @return StoreInterface the store or null if not found.
-     * @throws NotFoundException
-     */
-    public function getSelectedStore()
-    {
-        $store = null;
-        if ($this->nostoHelperScope->isSingleStoreMode()) {
-            $store = $this->nostoHelperScope->getStore(true);
-        } elseif (($storeId = $this->_request->getParam('store'))) {
-            $store = $this->nostoHelperScope->getStore($storeId);
-        } elseif (($this->nostoHelperScope->getStore())) {
-            $store = $this->nostoHelperScope->getStore();
-        } else {
-            throw new NotFoundException(__('Store not found.'));
-        }
-
-        return $store;
     }
 }

--- a/Controller/Adminhtml/Account/Index.php
+++ b/Controller/Adminhtml/Account/Index.php
@@ -39,6 +39,7 @@ namespace Nosto\Tagging\Controller\Adminhtml\Account;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Page;
 use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Api\Data\StoreInterface;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
@@ -98,15 +99,20 @@ class Index extends Base
      * If it is a multi store setup, the expect a store id to passed in the
      * request params and return that store as the current one.
      *
-     * @return StoreInterface|null the store or null if not found.
+     * @return StoreInterface the store or null if not found.
+     * @throws NotFoundException
      */
-    private function getSelectedStore()
+    public function getSelectedStore()
     {
         $store = null;
         if ($this->nostoHelperScope->isSingleStoreMode()) {
             $store = $this->nostoHelperScope->getStore(true);
-        } elseif (($storeId = $this->nostoHelperScope->getStore()->getId())) {
+        } elseif (($storeId = $this->_request->getParam('store'))) {
             $store = $this->nostoHelperScope->getStore($storeId);
+        } elseif (($this->nostoHelperScope->getStore())) {
+            $store = $this->nostoHelperScope->getStore();
+        } else {
+            throw new NotFoundException(__('Store not found.'));
         }
 
         return $store;

--- a/Helper/Scope.php
+++ b/Helper/Scope.php
@@ -38,6 +38,9 @@ namespace Nosto\Tagging\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Exception\NotFoundException;
+use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Website;
 
@@ -98,5 +101,30 @@ class Scope extends AbstractHelper
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->storeManager->getWebsites($withDefault, $codeKey);
+    }
+
+    /**
+     * Returns the currently selected store.
+     * If it is single store setup, then just return the default store.
+     * If it is a multi store setup, the expect a store id to passed in the
+     * request params and return that store as the current one.
+     *
+     * @return Store the store or null if not found.
+     * @throws NotFoundException
+     */
+    public function getSelectedStore(RequestInterface $request)
+    {
+        $store = null;
+        if ($this->isSingleStoreMode()) {
+            $store = $this->getStore(true);
+        } elseif ($storeId = $request->getParam('store')) {
+            $store = $this->getStore($storeId);
+        } elseif ($this->getStore()) {
+            $store = $this->getStore();
+        } else {
+            throw new NotFoundException(__('Store not found.'));
+        }
+
+        return $store;
     }
 }


### PR DESCRIPTION
I've got the project on maintenance with Magento EE 2.1.4 and a task to install Nosto module.

After installation:

```bash
composer require nosto/module-nostotagging ~2.0
```

I've started to get Inifite Redirect Loop error in my browser when I try to access Nosto admin page (Marketing / Nosto / Nosto Dashboard).

After a bit of research I figured out that `Controller/Adminhtml/Account/Index` tries to get current store with help of its `getSelectedStore` function this way:

```php
$store = null;
if ($this->nostoHelperScope->isSingleStoreMode()) {
    $store = $this->nostoHelperScope->getStore(true);
} elseif (($storeId = $this->nostoHelperScope->getStore()->getId())) {
    $store = $this->nostoHelperScope->getStore($storeId);
}

return $store;
```

The problem was that in my installation and Magento version `$this->nostoHelperScope->getStore()` always returned "0" (admin store). That means that the whole condition casted to false and `getSelectedStore` returned null.

After that, controller creates a redirect to the first store it's able to find, but the iteration repeats because `getSelectedScope` just ignores request parameter and tries again.

After a bit of investigation I discovered the same function in a Block and decided to pull it into Helper class and use it both in Block and Controller to avoid code duplication.