### PR TITLE
Fix the issue that nosto iframe failed to load on magento 2.1.x

### DIFF
--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -179,7 +179,7 @@ class Url extends AbstractHelper
      */
     public function getPreviewUrlProduct(Store $store)
     {
-        $product = $this->productRepository->getRandomSingleActiveProduct($store);
+        $product = $this->productRepository->getRandomSingleActiveProduct();
         $url = null;
         if ($product instanceof Product) {
             $url = $product->getUrlInStore(

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -48,6 +48,7 @@ use Magento\Store\Model\Store;
 use Nosto\Request\Http\HttpRequest;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Model\Product\Repository as ProductRepository;
+use Nosto\Tagging\Model\Product\Url\Builder as NostoUrlBuilder;
 
 /**
  * Url helper class for common URL related tasks.
@@ -135,6 +136,7 @@ class Url extends AbstractHelper
     private $nostoDataHelper;
     private $backendDataHelper;
     private $productRepository;
+    private $nostoUrlBuilder;
 
     /** @noinspection PhpUndefinedClassInspection */
     /**
@@ -147,6 +149,7 @@ class Url extends AbstractHelper
      * @param UrlBuilder $urlBuilder frontend URL builder.
      * @param Data $nostoDataHelper
      * @param BackendDataHelper $backendDataHelper
+     * @param NostoUrlBuilder $nostoUrlBuilder
      */
     public function __construct(
         Context $context,
@@ -156,7 +159,8 @@ class Url extends AbstractHelper
         Visibility $productVisibility,
         NostoDataHelper $nostoDataHelper,
         UrlBuilder $urlBuilder,
-        BackendDataHelper $backendDataHelper
+        BackendDataHelper $backendDataHelper,
+        NostoUrlBuilder $nostoUrlBuilder
     ) {
         parent::__construct($context);
 
@@ -166,6 +170,7 @@ class Url extends AbstractHelper
         $this->urlBuilder = $urlBuilder;
         $this->nostoDataHelper = $nostoDataHelper;
         $this->backendDataHelper = $backendDataHelper;
+        $this->nostoUrlBuilder = $nostoUrlBuilder;
     }
 
     /**
@@ -182,15 +187,10 @@ class Url extends AbstractHelper
         $product = $this->productRepository->getRandomSingleActiveProduct();
         $url = null;
         if ($product instanceof Product) {
-            $url = $product->getUrlInStore(
-                [
-                    self::MAGENTO_URL_OPTION_NOSID => true,
-                    self::MAGENTO_URL_OPTION_SCOPE_TO_URL => $this->nostoDataHelper->getStoreCodeToUrl($store),
-                    self::MAGENTO_URL_OPTION_SCOPE => $store->getCode(),
-                ]
-            );
+            $url = $this->nostoUrlBuilder->getUrlInStore($product, $store);
             $url = $this->addNostoDebugParamToUrl($url);
         }
+
         return $url;
     }
 

--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -153,12 +153,11 @@ class Repository
     /**
      * Gets a product that is active in a given Store
      *
-     * @param Store $store
      * @return Product|null
      * @suppress PhanTypeMismatchArgument
      *
      */
-    public function getRandomSingleActiveProduct(Store $store)
+    public function getRandomSingleActiveProduct()
     {
         $filterStatus = $this->filterBuilder
             ->setField('status')

--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -165,13 +165,13 @@ class Repository
             ->setConditionType('eq')
             ->create();
 
-        $filterVisbile = $this->filterBuilder
+        $filterVisible = $this->filterBuilder
             ->setField('visibility')
             ->setValue($this->productVisibility->getVisibleInSiteIds())
             ->setConditionType('in')
             ->create();
 
-        $filterGroup = $this->filterGroupBuilder->setFilters([$filterStatus, $filterVisbile])->create();
+        $filterGroup = $this->filterGroupBuilder->setFilters([$filterStatus, $filterVisible])->create();
         $searchCriteria = $this->searchCriteriaBuilder
             ->setFilterGroups([$filterGroup])
             ->setCurrentPage(1)

--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -166,13 +166,13 @@ class Repository
             ->setConditionType('eq')
             ->create();
 
-        $filterStore = $this->filterBuilder
-            ->setField('store')
-            ->setValue($store->getId())
-            ->setConditionType('eq')
+        $filterVisbile = $this->filterBuilder
+            ->setField('visibility')
+            ->setValue($this->productVisibility->getVisibleInSiteIds())
+            ->setConditionType('in')
             ->create();
 
-        $filterGroup = $this->filterGroupBuilder->setFilters([$filterStatus, $filterStore])->create();
+        $filterGroup = $this->filterGroupBuilder->setFilters([$filterStatus, $filterVisbile])->create();
         $searchCriteria = $this->searchCriteriaBuilder
             ->setFilterGroups([$filterGroup])
             ->setCurrentPage(1)


### PR DESCRIPTION
Filtering product by store fails on magento 2.1.* . That broke the whole nosto iframe in the backend. 
This PR remove the store filtering and add a visible filtering. 
Side effect: If the first product found is disabled on some of the substores but enabled on the others, it will be selected as the preview product even if the product is disabled on this particular sub store.

And it fixed that the  store code was missing from preview product url.