### PR TITLE
Fix price calculation to handle the tax settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 2.10.3
+* Fix Nosto product prices to obey the tax display setting
+
 ### 2.10.2
 * Add fallback for product URL builder in case the rewrites are missing
 

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -221,7 +221,10 @@ class Price extends AbstractHelper
                             && $sku->isAvailable()
                         ) {
                             $finalPrices[$sku->getId()] = $this->getProductPrice(
-                                $sku, $store, $inclTax, true
+                                $sku,
+                                $store,
+                                $inclTax,
+                                true
                             );
                             $skus[$sku->getId()] = $sku;
                         }

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -49,6 +49,7 @@ use Magento\Catalog\Model\ProductFactory;
 use Magento\CatalogRule\Model\ResourceModel\RuleFactory;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
+use Magento\Tax\Helper\Data as TaxHelper;
 
 /**
  * Price helper used for product price related tasks.
@@ -59,6 +60,7 @@ class Price extends AbstractHelper
     private $priceRuleFactory;
     private $localeDate;
     private $nostoProductRepository;
+    private $taxHelper;
 
     /**
      * Constructor.
@@ -74,13 +76,15 @@ class Price extends AbstractHelper
         CatalogHelper $catalogHelper,
         RuleFactory $ruleFactory,
         TimezoneInterface $localeDate,
-        NostoProductRepository $nostoProductRepository
+        NostoProductRepository $nostoProductRepository,
+        TaxHelper $taxHelper
     ) {
         parent::__construct($context);
         $this->catalogHelper = $catalogHelper;
         $this->priceRuleFactory = $ruleFactory;
         $this->localeDate = $localeDate;
         $this->nostoProductRepository = $nostoProductRepository;
+        $this->taxHelper = $taxHelper;
     }
 
     /**
@@ -91,7 +95,8 @@ class Price extends AbstractHelper
      */
     public function getProductDisplayPrice(Product $product)
     {
-        $price = $this->getProductPrice($product, false, true);
+        $incTax = $this->taxHelper->displayPriceIncludingTax();
+        $price = $this->getProductPrice($product, false, $incTax);
 
         return $price;
     }
@@ -249,6 +254,7 @@ class Price extends AbstractHelper
                 } else {
                     $price = $product->getPrice();
                 }
+
                 if ($inclTax) {
                     $price = $this->catalogHelper->getTaxPrice($product, $price, true);
                 }
@@ -266,7 +272,8 @@ class Price extends AbstractHelper
      */
     public function getProductFinalDisplayPrice(Product $product)
     {
-        $price = $this->getProductPrice($product, true, true);
+        $incTax = $this->taxHelper->displayPriceIncludingTax();
+        $price = $this->getProductPrice($product, true, $incTax);
 
         return $price;
     }

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -98,10 +98,11 @@ class Price extends AbstractHelper
      */
     public function getProductDisplayPrice(Product $product, Store $store)
     {
-        return $this->getProductPrice($product,
-            false,
+        return $this->getProductPrice(
+            $product,
+            $store,
             $this->includeTaxes($store),
-            $store
+            false
         );
     }
 
@@ -109,18 +110,18 @@ class Price extends AbstractHelper
      * Get unit/final price for a product model.
      *
      * @param Product $product the product model.
-     * @param bool $finalPrice if final price.
-     * @param bool $inclTax if tax is to be included.
      * @param Store $store
+     * @param bool $inclTax if tax is to be included.
+     * @param bool $finalPrice if final price.
      * @return float
      * @suppress PhanTypeMismatchArgument
      * @suppress PhanDeprecatedFunction
      */
     public function getProductPrice( // @codingStandardsIgnoreLine
         Product $product,
-        $finalPrice = false,
+        Store $store,
         $inclTax = true,
-        Store $store
+        $finalPrice = false
     ) {
         switch ($product->getTypeId()) {
             // Get the bundle product "from" price.
@@ -220,10 +221,7 @@ class Price extends AbstractHelper
                             && $sku->isAvailable()
                         ) {
                             $finalPrices[$sku->getId()] = $this->getProductPrice(
-                                $sku,
-                                true,
-                                $inclTax,
-                                $store
+                                $sku, $store, $inclTax, true
                             );
                             $skus[$sku->getId()] = $sku;
                         }
@@ -262,7 +260,8 @@ class Price extends AbstractHelper
                     $price = $product->getPrice();
                 }
                 if ($inclTax) {
-                    $price = $this->catalogHelper->getTaxPrice($product,
+                    $price = $this->catalogHelper->getTaxPrice(
+                        $product,
                         $price,
                         true,
                         null,
@@ -286,10 +285,11 @@ class Price extends AbstractHelper
      */
     public function getProductFinalDisplayPrice(Product $product, Store $store)
     {
-        return $this->getProductPrice($product,
-            true,
+        return $this->getProductPrice(
+            $product,
+            $store,
             $this->includeTaxes($store),
-            $store
+            true
         );
     }
 

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -297,7 +297,7 @@ class Price extends AbstractHelper
     }
 
     /**
-     * Tells is taxes should be added to the prices.
+     * Tells if taxes should be added to the prices.
      * We need this method due to the bugs in Magento's store emulation that
      * are not setting the tax display settings correctly for the API calls.
      *
@@ -309,7 +309,7 @@ class Price extends AbstractHelper
      */
     private function includeTaxes(Store $store)
     {
-        if ($this->taxHelper->getPriceDisplayType($store) == TaxConfig::DISPLAY_TYPE_INCLUDING_TAX) {
+        if ($this->taxHelper->getPriceDisplayType($store) === TaxConfig::DISPLAY_TYPE_INCLUDING_TAX) {
             return true;
         }
 

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -160,14 +160,16 @@ class Builder
             $nostoProduct->setImageUrl($this->buildImageUrl($product, $store));
             $price = $this->nostoCurrencyHelper->convertToTaggingPrice(
                 $this->nostoPriceHelper->getProductFinalDisplayPrice(
-                    $product
+                    $product,
+                    $store
                 ),
                 $store
             );
             $nostoProduct->setPrice($price);
             $listPrice = $this->nostoCurrencyHelper->convertToTaggingPrice(
                 $this->nostoPriceHelper->getProductDisplayPrice(
-                    $product
+                    $product,
+                    $store
                 ),
                 $store
             );

--- a/Model/Product/Sku/Builder.php
+++ b/Model/Product/Sku/Builder.php
@@ -104,14 +104,16 @@ class Builder
             $nostoSku->setImageUrl($this->buildImageUrl($product, $store));
             $price = $this->nostoCurrencyHelper->convertToTaggingPrice(
                 $this->nostoPriceHelper->getProductFinalDisplayPrice(
-                    $product
+                    $product,
+                    $store
                 ),
                 $store
             );
             $nostoSku->setPrice($price);
             $listPrice = $this->nostoCurrencyHelper->convertToTaggingPrice(
                 $this->nostoPriceHelper->getProductDisplayPrice(
-                    $product
+                    $product,
+                    $store
                 ),
                 $store
             );

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "require-dev": {
     "php": ">=5.5.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="2.10.2"/>
+    <module name="Nosto_Tagging" setup_version="2.10.3"/>
 </config>


### PR DESCRIPTION
Tips for testing
* Create tax rate, simple tax rule & tax class  
* Create two stores - other configured to display product prices with taxes and the other one without taxes (see screenshot)
* Browse few products with `nostodebug=true` and save the products in store admin as well 
* Make sure the prices are correct in tagging and in API calls    