### PR TITLE
Feature - Move the message type check (starts with [Nosto]) before the regexp check

### DIFF
--- a/view/adminhtml/web/js/iframe_handler.js
+++ b/view/adminhtml/web/js/iframe_handler.js
@@ -71,13 +71,15 @@ define([
      * @param {Object} event
      */
     var receiveMessage = function (event) {
+        // If the message does not start with '[Nosto]', then it is not for us.
+        if (('' + event.data).substr(0, 7) !== '[Nosto]') {
+            return;
+        }
+
         // Check the origin to prevent cross-site scripting.
         var originRegexp = new RegExp(settings.origin);
         if (!originRegexp.test(event.origin)) {
-            return;
-        }
-        // If the message does not start with '[Nosto]', then it is not for us.
-        if (('' + event.data).substr(0, 7) !== '[Nosto]') {
+            console.warn('Requested URL does not matches iframe origin');
             return;
         }
 


### PR DESCRIPTION
- Add console log / console warning when iframe regexp test fails.
Closes #296 