### PR TITLE
Always return an array from the buildCustomFields method, otherwise w…

### DIFF
--- a/Model/Product/BuilderTrait.php
+++ b/Model/Product/BuilderTrait.php
@@ -66,15 +66,15 @@ trait BuilderTrait
      *
      * @param Product $product
      * @param Store $store
-     * @return array|null
+     * @return array
      */
     public function buildCustomFields(Product $product, Store $store)
     {
-        if (!$this->nostoDataHelperTrait->isCustomFieldsEnabled($store)) {
-            return null;
-        }
-
         $customFields = [];
+
+        if (!$this->nostoDataHelperTrait->isCustomFieldsEnabled($store)) {
+            return $customFields;
+        }
 
         $attributes = $product->getTypeInstance()->getSetAttributes($product);
         /** @var AbstractAttribute $attribute */


### PR DESCRIPTION
…hen returning null it couldn't be used directly in the 'setCustomFields' method. Fixes #306