### PR TITLE
Store abstractObject in a temporary variable, instead of calling 'get…

### DIFF
--- a/Block/TaggingTrait.php
+++ b/Block/TaggingTrait.php
@@ -69,8 +69,9 @@ trait TaggingTrait
     public function _toHtml()
     {
         if ($this->nostoHelperAccount->nostoInstalledAndEnabled($this->nostoHelperScope->getStore())) {
-            if ($this->getAbstractObject() instanceof AbstractObject) {
-                return $this->getAbstractObject()->toHtml();
+            $abstractObject = $this->getAbstractObject();
+            if ($abstractObject instanceof AbstractObject) {
+                return $abstractObject->toHtml();
             }
             return parent::_toHtml();
         }


### PR DESCRIPTION
…AbstractObject' twice. Has a pretty significant impact on performance. Fixes #305