### PR TITLE
Check if Magento_Review module is enabled

### DIFF
--- a/Helper/Ratings.php
+++ b/Helper/Ratings.php
@@ -126,7 +126,7 @@ class Ratings extends AbstractHelper
      */
     private function getRatingsFromProviders(Product $product, Store $store)
     {
-        if ($this->nostoDataHelper->isRatingTaggingEnabled($store) && $this->isReviewModuleEnabled()) {
+        if ($this->nostoDataHelper->isRatingTaggingEnabled($store)) {
             $provider = $this->nostoDataHelper->getRatingTaggingProvider($store);
 
             if ($provider === NostoHelperData::SETTING_VALUE_YOTPO_RATINGS) {
@@ -158,6 +158,10 @@ class Ratings extends AbstractHelper
             }
 
             if ($provider === NostoHelperData::SETTING_VALUE_MAGENTO_RATINGS) {
+                if (!$this->canUseMagentoRatingsAndReviews()) {
+                    return null;
+                }
+
                 return [
                     self::AVERAGE_SCORE => $this->buildRatingValue($product, $store),
                     self::REVIEW_COUNT => $this->buildReviewCount($product, $store)
@@ -223,7 +227,7 @@ class Ratings extends AbstractHelper
      */
     public function canUseYotpo()
     {
-        if ($this->moduleManager->isEnabled("Yotpo_Yotpo") &&
+        if ($this->moduleManager->isEnabled('Yotpo_Yotpo') &&
             class_exists('Yotpo\Yotpo\Helper\RichSnippets') &&
             method_exists($this->ratingsFactory->create(), 'getRichSnippet')
         ) {
@@ -238,9 +242,9 @@ class Ratings extends AbstractHelper
      *
      * @return bool
      */
-    public function isReviewModuleEnabled()
+    public function canUseMagentoRatingsAndReviews()
     {
-        if ($this->moduleManager->isEnabled("Magento_Review")) {
+        if ($this->moduleManager->isEnabled('Magento_Review')) {
             return true;
         }
 

--- a/Helper/Ratings.php
+++ b/Helper/Ratings.php
@@ -157,11 +157,8 @@ class Ratings extends AbstractHelper
                 ];
             }
 
-            if ($provider === NostoHelperData::SETTING_VALUE_MAGENTO_RATINGS) {
-                if (!$this->canUseMagentoRatingsAndReviews()) {
-                    return null;
-                }
-
+            if ($provider === NostoHelperData::SETTING_VALUE_MAGENTO_RATINGS &&
+                $this->canUseMagentoRatingsAndReviews()) {
                 return [
                     self::AVERAGE_SCORE => $this->buildRatingValue($product, $store),
                     self::REVIEW_COUNT => $this->buildReviewCount($product, $store)
@@ -244,11 +241,7 @@ class Ratings extends AbstractHelper
      */
     public function canUseMagentoRatingsAndReviews()
     {
-        if ($this->moduleManager->isEnabled('Magento_Review')) {
-            return true;
-        }
-
-        return false;
+        return $this->moduleManager->isEnabled('Magento_Review');
     }
 
     /**

--- a/Helper/Ratings.php
+++ b/Helper/Ratings.php
@@ -126,7 +126,7 @@ class Ratings extends AbstractHelper
      */
     private function getRatingsFromProviders(Product $product, Store $store)
     {
-        if ($this->nostoDataHelper->isRatingTaggingEnabled($store)) {
+        if ($this->nostoDataHelper->isRatingTaggingEnabled($store) && $this->isReviewModuleEnabled()) {
             $provider = $this->nostoDataHelper->getRatingTaggingProvider($store);
 
             if ($provider === NostoHelperData::SETTING_VALUE_YOTPO_RATINGS) {
@@ -227,6 +227,20 @@ class Ratings extends AbstractHelper
             class_exists('Yotpo\Yotpo\Helper\RichSnippets') &&
             method_exists($this->ratingsFactory->create(), 'getRichSnippet')
         ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the Review module is enabled, review tables are present
+     *
+     * @return bool
+     */
+    public function isReviewModuleEnabled()
+    {
+        if ($this->moduleManager->isEnabled("Magento_Review")) {
             return true;
         }
 

--- a/Model/Config/Source/Ratings.php
+++ b/Model/Config/Source/Ratings.php
@@ -77,8 +77,8 @@ class Ratings implements ArrayInterface
         }
 
         if ($this->nostoRatingsHelper->canUseMagentoRatingsAndReviews()) {
-            $magentoRatings = ['value' => Data::SETTING_VALUE_MAGENTO_RATINGS, 'label' => new Phrase('Magento Ratings')];
-            $options[] = $magentoRatings;
+            $mageRatings = ['value' => Data::SETTING_VALUE_MAGENTO_RATINGS, 'label' => new Phrase('Magento Ratings')];
+            $options[] = $mageRatings;
         }
 
         return $options;

--- a/Model/Config/Source/Ratings.php
+++ b/Model/Config/Source/Ratings.php
@@ -68,13 +68,17 @@ class Ratings implements ArrayInterface
     public function toOptionArray()
     {
         $options = [
-            ['value' => Data::SETTING_VALUE_MAGENTO_RATINGS, 'label' => new Phrase('Magento Ratings')],
             ['value' => Data::SETTING_VALUE_NO_RATINGS, 'label' => new Phrase('No Ratings')]
         ];
 
         if ($this->nostoRatingsHelper->canUseYotpo()) {
             $yotpo =  ['value' => Data::SETTING_VALUE_YOTPO_RATINGS, 'label' => new Phrase('Yotpo Ratings')];
             $options[]= $yotpo;
+        }
+
+        if ($this->nostoRatingsHelper->canUseMagentoRatingsAndReviews()) {
+            $magentoRatings = ['value' => Data::SETTING_VALUE_MAGENTO_RATINGS, 'label' => new Phrase('Magento Ratings')];
+            $options[] = $magentoRatings;
         }
 
         return $options;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added method to check if `Magento_Review` module is enabled

## Related Issue
close #360

## Motivation and Context
Review related tables are deleted when disabling this module resulting in a bug on Nosto side.

## How Has This Been Tested?

## Documentation:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
