### PR TITLE
Hotfix 3.0.3 - Line item without product

### DIFF
--- a/Model/Cart/Item/Builder.php
+++ b/Model/Cart/Item/Builder.php
@@ -144,7 +144,13 @@ class Builder
                 return $parentIds[0];
             }
         }
-        return (string)$item->getProduct()->getId();
+
+        $product = $item->getProduct();
+        $productId = $product ? (string)$product->getId() : '';
+        if (trim($productId) === '') {
+            return LineItem::PSEUDO_PRODUCT_ID;
+        }
+        return $productId;
     }
 
     /**

--- a/Model/Cart/Item/Builder.php
+++ b/Model/Cart/Item/Builder.php
@@ -37,16 +37,16 @@
 namespace Nosto\Tagging\Model\Cart\Item;
 
 use Exception;
+use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\ProductRepository;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote\Item;
-use Magento\Catalog\Model\Product;
 use Nosto\Object\Cart\LineItem;
 use Nosto\Tagging\Model\Item\Downloadable;
 use Nosto\Tagging\Model\Item\Giftcard;
 use Nosto\Tagging\Model\Item\Virtual;
-use Magento\Catalog\Model\ProductRepository;
 
 class Builder
 {
@@ -144,13 +144,11 @@ class Builder
                 return $parentIds[0];
             }
         }
-
         $product = $item->getProduct();
-        $productId = $product ? (string)$product->getId() : '';
-        if (trim($productId) === '') {
-            return LineItem::PSEUDO_PRODUCT_ID;
+        if ($product instanceof Product) {
+            return $product->getId();
         }
-        return $productId;
+        return LineItem::PSEUDO_PRODUCT_ID;
     }
 
     /**

--- a/Model/Cart/Item/Builder.php
+++ b/Model/Cart/Item/Builder.php
@@ -146,7 +146,7 @@ class Builder
         }
         $product = $item->getProduct();
         if ($product instanceof Product) {
-            return $product->getId();
+            return (string)$product->getId();
         }
         return LineItem::PSEUDO_PRODUCT_ID;
     }

--- a/Model/Order/Item/Builder.php
+++ b/Model/Order/Item/Builder.php
@@ -165,7 +165,11 @@ class Builder
                 return $parentIds[0];
             }
         }
-        return (string)$item->getProductId();
+        $productId = (string)$item->getProductId();
+        if (trim($productId) === '') {
+            return LineItem::PSEUDO_PRODUCT_ID;
+        }
+        return $productId;
     }
 
     /**

--- a/Model/Order/Item/Builder.php
+++ b/Model/Order/Item/Builder.php
@@ -165,8 +165,8 @@ class Builder
                 return $parentIds[0];
             }
         }
-        $productId = (string)$item->getProductId();
-        if (trim($productId) === '') {
+        $productId = $item->getProductId();
+        if (!$productId) {
             return LineItem::PSEUDO_PRODUCT_ID;
         }
         return $productId;

--- a/Model/Order/Item/Builder.php
+++ b/Model/Order/Item/Builder.php
@@ -169,7 +169,7 @@ class Builder
         if (!$productId) {
             return LineItem::PSEUDO_PRODUCT_ID;
         }
-        return $productId;
+        return (string)$productId;
     }
 
     /**


### PR DESCRIPTION
## Description
Some line items can have a product associated that no longer exist, and when trying to fetch the id, would throw a fatal error.

## Related Issue
Closes #339 

## How Has This Been Tested?
- Tested Manually Locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
