### PR TITLE
Disable autoencode for search term

### DIFF
--- a/Block/Search.php
+++ b/Block/Search.php
@@ -44,6 +44,7 @@ use Magento\Search\Model\QueryFactory;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Object\MarkupableString;
+use Nosto\Object\SearchTerm;
 
 /**
  * Search block used for outputting meta-data on the stores search pages.
@@ -97,11 +98,11 @@ class Search extends Result
      */
     public function getAbstractObject()
     {
-        $markupableString = new MarkupableString(
+        $searchTerm = new SearchTerm(
             $this->getNostoSearchTerm(),
             'nosto_search_term'
         );
-        $markupableString->disableAutoEncodeAll();
-        return $markupableString;
+        $searchTerm->disableAutoEncodeAll();
+        return $searchTerm;
     }
 }

--- a/Block/Search.php
+++ b/Block/Search.php
@@ -99,8 +99,7 @@ class Search extends Result
     public function getAbstractObject()
     {
         $searchTerm = new SearchTerm(
-            $this->getNostoSearchTerm(),
-            'nosto_search_term'
+            $this->getNostoSearchTerm()
         );
         $searchTerm->disableAutoEncodeAll();
         return $searchTerm;

--- a/Block/Search.php
+++ b/Block/Search.php
@@ -97,9 +97,11 @@ class Search extends Result
      */
     public function getAbstractObject()
     {
-        return new MarkupableString(
+        $markupableString = new MarkupableString(
             $this->getNostoSearchTerm(),
             'nosto_search_term'
         );
+        $markupableString->disableAutoEncodeAll();
+        return $markupableString;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "nosto/php-sdk": "3.9.2"
+    "nosto/php-sdk": "dev-feature/add-html-encoding"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "nosto/php-sdk": "dev-feature/add-html-encoding"
+    "nosto/php-sdk": "3.10.0"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8bdcc1b2d925d1278e9a5eabdb381b4",
+    "content-hash": "6bcdf1aff28bb7f3013dd021b7571a19",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "3.9.2",
+            "version": "dev-feature/add-html-encoding",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "489ada0cc6d69a14fbe27e2d3edb514f0908f9e2"
+                "reference": "32e94bbd7c2a07712153f441e59cbe3ff1d015e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/489ada0cc6d69a14fbe27e2d3edb514f0908f9e2",
-                "reference": "489ada0cc6d69a14fbe27e2d3edb514f0908f9e2",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/32e94bbd7c2a07712153f441e59cbe3ff1d015e9",
+                "reference": "32e94bbd7c2a07712153f441e59cbe3ff1d015e9",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-02-05T12:36:41+00:00"
+            "time": "2019-02-12T13:42:48+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -5924,6 +5924,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "nosto/php-sdk": 20,
         "magento/marketplace-tools": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bcdf1aff28bb7f3013dd021b7571a19",
+    "content-hash": "acf0cb5892a9b86da27088cd87a490de",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "dev-feature/add-html-encoding",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "32e94bbd7c2a07712153f441e59cbe3ff1d015e9"
+                "reference": "65dc7435d6036c6efc0add591bf3adbb60a4a3c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/32e94bbd7c2a07712153f441e59cbe3ff1d015e9",
-                "reference": "32e94bbd7c2a07712153f441e59cbe3ff1d015e9",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/65dc7435d6036c6efc0add591bf3adbb60a4a3c4",
+                "reference": "65dc7435d6036c6efc0add591bf3adbb60a4a3c4",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-02-12T13:42:48+00:00"
+            "time": "2019-02-19T13:16:14+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -395,12 +395,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "d788c67547708248e843d2feabeb16b20b35a618"
+                "reference": "69745745b39bf6b24c8f88dc18b44980ee042e28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/d788c67547708248e843d2feabeb16b20b35a618",
-                "reference": "d788c67547708248e843d2feabeb16b20b35a618",
+                "url": "https://api.github.com/repos/composer/composer/zipball/69745745b39bf6b24c8f88dc18b44980ee042e28",
+                "reference": "69745745b39bf6b24c8f88dc18b44980ee042e28",
                 "shasum": ""
             },
             "require": {
@@ -467,7 +467,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-02-11T09:52:53+00:00"
+            "time": "2019-02-16T16:56:20+00:00"
         },
         {
             "name": "composer/semver",
@@ -3675,12 +3675,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "4893d49525d2617cf6fae6a9b1c168030e4a22ea"
+                "reference": "95a6897c75ecd816e8990aa5e9c671d76eea9ba7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/4893d49525d2617cf6fae6a9b1c168030e4a22ea",
-                "reference": "4893d49525d2617cf6fae6a9b1c168030e4a22ea",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/95a6897c75ecd816e8990aa5e9c671d76eea9ba7",
+                "reference": "95a6897c75ecd816e8990aa5e9c671d76eea9ba7",
                 "shasum": ""
             },
             "require": {
@@ -3716,7 +3716,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-08T13:52:14+00:00"
+            "time": "2019-02-11T12:49:33+00:00"
         },
         {
             "name": "psr/container",
@@ -4174,12 +4174,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "e8f2ea3e9ab1e7bf27793b47d03e49aca6c8e2ca"
+                "reference": "b8f4eaed0131c05a18c595b7d9026d88e93508ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/e8f2ea3e9ab1e7bf27793b47d03e49aca6c8e2ca",
-                "reference": "e8f2ea3e9ab1e7bf27793b47d03e49aca6c8e2ca",
+                "url": "https://api.github.com/repos/symfony/config/zipball/b8f4eaed0131c05a18c595b7d9026d88e93508ae",
+                "reference": "b8f4eaed0131c05a18c595b7d9026d88e93508ae",
                 "shasum": ""
             },
             "require": {
@@ -4229,7 +4229,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-30T11:44:59+00:00"
+            "time": "2019-02-17T09:56:33+00:00"
         },
         {
             "name": "symfony/console",
@@ -5924,7 +5924,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "nosto/php-sdk": 20,
         "magento/marketplace-tools": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disable encoding the HTML tags on the SDK side.

## Related Issue
closes #379

## Motivation and Context
The search term is encoded by Magento, so it should not be encoded again to avoid double encoding.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
