### PR TITLE
Add possibility to define Nosto account & active domain

### DIFF
--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -286,8 +286,7 @@ class Url extends AbstractHelper
      */
     public function getActiveDomain(Store $store)
     {
-        $url =  $store->getBaseUrl();
-        return UrlHelper::parseUrl($url);
+        return UrlHelper::parseUrl($store->getBaseUrl());
     }
 
     /**

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -50,6 +50,7 @@ use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Model\Product\Repository as ProductRepository;
 use Nosto\Tagging\Model\Product\Url\Builder as NostoUrlBuilder;
 use Nosto\Helper\UrlHelper;
+use Nosto\Tagging\Logger\Logger as NostoLogger;
 
 /**
  * Url helper class for common URL related tasks.
@@ -137,6 +138,7 @@ class Url extends AbstractHelper
     private $backendDataHelper;
     private $productRepository;
     private $nostoUrlBuilder;
+    private $logger;
 
     /** @noinspection PhpUndefinedClassInspection */
     /**
@@ -159,7 +161,8 @@ class Url extends AbstractHelper
         UrlBuilder $urlBuilder,
         /** @noinspection PhpDeprecationInspection */
         BackendDataHelper $backendDataHelper,
-        NostoUrlBuilder $nostoUrlBuilder
+        NostoUrlBuilder $nostoUrlBuilder,
+        NostoLogger $nostoLogger
     ) {
         parent::__construct($context);
 
@@ -169,6 +172,7 @@ class Url extends AbstractHelper
         $this->nostoDataHelper = $nostoDataHelper;
         $this->backendDataHelper = $backendDataHelper;
         $this->nostoUrlBuilder = $nostoUrlBuilder;
+        $this->logger = $nostoLogger;
     }
 
     /**
@@ -282,11 +286,18 @@ class Url extends AbstractHelper
     /**
      * Returns the store domain
      *
+     * @param Store $store
      * @return string
      */
     public function getActiveDomain(Store $store)
     {
-        return UrlHelper::parseDomain($store->getBaseUrl());
+        try {
+            return UrlHelper::parseDomain($store->getBaseUrl());
+        } catch (\Exception $e) {
+            $this->logger->exception($e);
+            return '';
+        }
+
     }
 
     /**

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -49,7 +49,6 @@ use Nosto\Request\Http\HttpRequest;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Model\Product\Repository as ProductRepository;
 use Nosto\Tagging\Model\Product\Url\Builder as NostoUrlBuilder;
-use Magento\Framework\ObjectManagerInterface;
 use Nosto\Helper\UrlHelper;
 
 /**
@@ -138,7 +137,6 @@ class Url extends AbstractHelper
     private $backendDataHelper;
     private $productRepository;
     private $nostoUrlBuilder;
-    private $objectManager;
 
     /** @noinspection PhpUndefinedClassInspection */
     /**
@@ -161,8 +159,7 @@ class Url extends AbstractHelper
         UrlBuilder $urlBuilder,
         /** @noinspection PhpDeprecationInspection */
         BackendDataHelper $backendDataHelper,
-        NostoUrlBuilder $nostoUrlBuilder,
-        ObjectManagerInterface $objectManager
+        NostoUrlBuilder $nostoUrlBuilder
     ) {
         parent::__construct($context);
 
@@ -172,7 +169,6 @@ class Url extends AbstractHelper
         $this->nostoDataHelper = $nostoDataHelper;
         $this->backendDataHelper = $backendDataHelper;
         $this->nostoUrlBuilder = $nostoUrlBuilder;
-        $this->objectManager = $objectManager;
     }
 
     /**
@@ -288,10 +284,9 @@ class Url extends AbstractHelper
      *
      * @return string
      */
-    public function getActiveDomain()
+    public function getActiveDomain(Store $store)
     {
-        $storeManager = $this->objectManager->get('\Magento\Store\Model\StoreManagerInterface');
-        $url =  $storeManager->getStore()->getBaseUrl();
+        $url =  $store->getBaseUrl();
         return UrlHelper::parseUrl($url);
     }
 

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -297,7 +297,6 @@ class Url extends AbstractHelper
             $this->logger->exception($e);
             return '';
         }
-
     }
 
     /**

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -49,6 +49,8 @@ use Nosto\Request\Http\HttpRequest;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Model\Product\Repository as ProductRepository;
 use Nosto\Tagging\Model\Product\Url\Builder as NostoUrlBuilder;
+use Magento\Framework\ObjectManagerInterface;
+use Nosto\Helper\UrlHelper;
 
 /**
  * Url helper class for common URL related tasks.
@@ -136,6 +138,7 @@ class Url extends AbstractHelper
     private $backendDataHelper;
     private $productRepository;
     private $nostoUrlBuilder;
+    private $objectManager;
 
     /** @noinspection PhpUndefinedClassInspection */
     /**
@@ -158,7 +161,8 @@ class Url extends AbstractHelper
         UrlBuilder $urlBuilder,
         /** @noinspection PhpDeprecationInspection */
         BackendDataHelper $backendDataHelper,
-        NostoUrlBuilder $nostoUrlBuilder
+        NostoUrlBuilder $nostoUrlBuilder,
+        ObjectManagerInterface $objectManager
     ) {
         parent::__construct($context);
 
@@ -168,6 +172,7 @@ class Url extends AbstractHelper
         $this->nostoDataHelper = $nostoDataHelper;
         $this->backendDataHelper = $backendDataHelper;
         $this->nostoUrlBuilder = $nostoUrlBuilder;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -276,6 +281,18 @@ class Url extends AbstractHelper
         );
         $url = $this->replaceQueryParamsInUrl(['q' => 'nosto'], $url);
         return $this->addNostoDebugParamToUrl($url);
+    }
+
+    /**
+     * Returns the store domain
+     *
+     * @return string
+     */
+    public function getActiveDomain()
+    {
+        $storeManager = $this->objectManager->get('\Magento\Store\Model\StoreManagerInterface');
+        $url =  $storeManager->getStore()->getBaseUrl();
+        return UrlHelper::parseUrl($url);
     }
 
     /**

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -286,7 +286,7 @@ class Url extends AbstractHelper
      */
     public function getActiveDomain(Store $store)
     {
-        return UrlHelper::parseUrl($store->getBaseUrl());
+        return UrlHelper::parseDomain($store->getBaseUrl());
     }
 
     /**

--- a/Model/Product/Service.php
+++ b/Model/Product/Service.php
@@ -96,6 +96,7 @@ class Service
      * @param StoreManager $storeManager
      * @param ProductFactory $productFactory
      * @param Emulation $emulation
+     * @param NostoHelperUrl $nostoHelperUrl
      */
     public function __construct(
         NostoLogger $logger,

--- a/Model/Product/Service.php
+++ b/Model/Product/Service.php
@@ -53,6 +53,7 @@ use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Product\Builder as NostoProductBuilder;
 use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
 use Nosto\Types\Product\ProductInterface as NostoProductInterface;
+use Nosto\Tagging\Helper\Url as NostoHelperUrl;
 
 /**
  * Service class for updating products to Nosto
@@ -75,6 +76,7 @@ class Service
     private $productFactory;
     private $nostoQueueRepository;
     private $storeEmulator;
+    private $nostoHelperUrl;
 
     public $processed = [];
 
@@ -105,7 +107,8 @@ class Service
         QueueFactory $nostoQueueFactory,
         StoreManager $storeManager,
         ProductFactory $productFactory,
-        Emulation $emulation
+        Emulation $emulation,
+        NostoHelperUrl $nostoHelperUrl
     ) {
         $this->logger = $logger;
         $this->nostoProductBuilder = $nostoProductBuilder;
@@ -117,6 +120,7 @@ class Service
         $this->storeManager = $storeManager;
         $this->productFactory = $productFactory;
         $this->storeEmulator = $emulation;
+        $this->nostoHelperUrl = $nostoHelperUrl;
     }
 
     /**
@@ -321,7 +325,7 @@ class Service
         $productIdsStillExist = [];
 
         if (!empty($productsStillExist)) {
-            $op = new UpsertProduct($nostoAccount);
+            $op = new UpsertProduct($nostoAccount, $this->nostoHelperUrl->getActiveDomain());
             $op->setResponseTimeout(self::$responseTimeOut);
 
             /* @var Product $product */

--- a/Model/Product/Service.php
+++ b/Model/Product/Service.php
@@ -325,7 +325,7 @@ class Service
         $productIdsStillExist = [];
 
         if (!empty($productsStillExist)) {
-            $op = new UpsertProduct($nostoAccount, $this->nostoHelperUrl->getActiveDomain());
+            $op = new UpsertProduct($nostoAccount, $this->nostoHelperUrl->getActiveDomain($store));
             $op->setResponseTimeout(self::$responseTimeOut);
 
             /* @var Product $product */

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -127,9 +127,10 @@ class Save implements ObserverInterface
             /* @var Order $order */
             /** @noinspection PhpUndefinedMethodInspection */
             $order = $observer->getOrder();
+            $store = $order->getStore();
             $nostoOrder = $this->nostoOrderBuilder->build($order);
             $nostoAccount = $this->nostoHelperAccount->findAccount(
-                $this->nostoHelperScope->getStore()
+                $store
             );
             if ($nostoAccount !== null) {
                 $quoteId = $order->getQuoteId();
@@ -139,7 +140,6 @@ class Save implements ObserverInterface
                 if ($nostoCustomer instanceof NostoCustomer === false) {
                     return;
                 }
-                $store = $order->getStore();
                 $orderService = new OrderConfirm($nostoAccount, $this->nostoHelperUrl->getActiveDomain($store));
                 try {
                     $orderService->send($nostoOrder, $nostoCustomer->getNostoId());

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -82,6 +82,7 @@ class Save implements ObserverInterface
      * @param CustomerRepository $customerRepository
      * @param NostoOrderBuilder $orderBuilder
      * @param IndexerRegistry $indexerRegistry
+     * @param NostoHelperUrl $nostoHelperUrl
      */
     public function __construct(
         NostoHelperData $nostoHelperData,

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -52,6 +52,7 @@ use Nosto\Tagging\Model\Customer\Repository as CustomerRepository;
 use Nosto\Tagging\Model\Indexer\Product\Indexer;
 use Nosto\Tagging\Model\Order\Builder as NostoOrderBuilder;
 use Nosto\Object\Order\Order as NostoOrder;
+use Nosto\Tagging\Helper\Url as NostoHelperUrl;
 
 /**
  * Class Save
@@ -67,6 +68,7 @@ class Save implements ObserverInterface
     private $customerRepository;
     private $nostoHelperScope;
     private $indexer;
+    private $nostoHelperUrl;
 
     /** @noinspection PhpUndefinedClassInspection */
     /**
@@ -90,7 +92,8 @@ class Save implements ObserverInterface
         /** @noinspection PhpUndefinedClassInspection */
         CustomerRepository $customerRepository,
         NostoOrderBuilder $orderBuilder,
-        IndexerRegistry $indexerRegistry
+        IndexerRegistry $indexerRegistry,
+        NostoHelperUrl $nostoHelperUrl
     ) {
         $this->nostoHelperData = $nostoHelperData;
         $this->nostoHelperAccount = $nostoHelperAccount;
@@ -100,6 +103,7 @@ class Save implements ObserverInterface
         $this->customerRepository = $customerRepository;
         $this->indexer = $indexerRegistry->get(Indexer::INDEXER_ID);
         $this->nostoHelperScope = $nostoHelperScope;
+        $this->nostoHelperUrl = $nostoHelperUrl;
     }
 
     /**
@@ -134,7 +138,8 @@ class Save implements ObserverInterface
                 if ($nostoCustomer instanceof NostoCustomer === false) {
                     return;
                 }
-                $orderService = new OrderConfirm($nostoAccount);
+                $store = $order->getStore();
+                $orderService = new OrderConfirm($nostoAccount, $this->nostoHelperUrl->getActiveDomain($store));
                 try {
                     $orderService->send($nostoOrder, $nostoCustomer->getNostoId());
                 } catch (\Exception $e) {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "nosto/php-sdk": "dev-hotfix/3.10.1"
+    "nosto/php-sdk": "3.10.1"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "nosto/php-sdk": "3.10.0"
+    "nosto/php-sdk": "dev-hotfix/3.10.1"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "nosto/php-sdk": "3.10.1"
+    "nosto/php-sdk": "3.11.0"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65c074d7997427bd9aaa1750e607637e",
+    "content-hash": "dfb281926bc833bef5236c5c256b2a1d",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "dev-hotfix/3.10.1",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "bbbfee24edd577c48c03664009d6bf4f35b48e64"
+                "reference": "3b5bd711ec1288071a02483b0ead4b6eb70b4ecb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/bbbfee24edd577c48c03664009d6bf4f35b48e64",
-                "reference": "bbbfee24edd577c48c03664009d6bf4f35b48e64",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/3b5bd711ec1288071a02483b0ead4b6eb70b4ecb",
+                "reference": "3b5bd711ec1288071a02483b0ead4b6eb70b4ecb",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-02-25T09:46:34+00:00"
+            "time": "2019-03-05T12:47:12+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -59,12 +59,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "926e43af9d12cbd2510889ca370dd2c5d1e26726"
+                "reference": "ed975a270d7c5dca9d9be73f3b66beca0407eded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/926e43af9d12cbd2510889ca370dd2c5d1e26726",
-                "reference": "926e43af9d12cbd2510889ca370dd2c5d1e26726",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/ed975a270d7c5dca9d9be73f3b66beca0407eded",
+                "reference": "ed975a270d7c5dca9d9be73f3b66beca0407eded",
                 "shasum": ""
             },
             "require": {
@@ -143,7 +143,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2019-02-25T03:36:40+00:00"
+            "time": "2019-03-04T14:15:45+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -395,12 +395,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "60f198c17d99728b0c1adb5b17e581fe274e34e8"
+                "reference": "522ea033a3c6e72d72954f7cd019a3b75e28f391"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/60f198c17d99728b0c1adb5b17e581fe274e34e8",
-                "reference": "60f198c17d99728b0c1adb5b17e581fe274e34e8",
+                "url": "https://api.github.com/repos/composer/composer/zipball/522ea033a3c6e72d72954f7cd019a3b75e28f391",
+                "reference": "522ea033a3c6e72d72954f7cd019a3b75e28f391",
                 "shasum": ""
             },
             "require": {
@@ -467,7 +467,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-02-21T13:06:41+00:00"
+            "time": "2019-03-04T16:26:35+00:00"
         },
         {
             "name": "composer/semver",
@@ -853,8 +853,7 @@
                 "url": "https://github.com/magento/marketplace-tools",
                 "reference": "origin/master"
             },
-            "type": "library",
-            "time": "2017-04-06T01:16:20+00:00"
+            "type": "library"
         },
         {
             "name": "magento/module-authorization",
@@ -4425,12 +4424,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "13f7596671e3bf6cb293ee20e72083740382077c"
+                "reference": "fc2eed9862f01faa64ee93aa2655467b184bfe4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/13f7596671e3bf6cb293ee20e72083740382077c",
-                "reference": "13f7596671e3bf6cb293ee20e72083740382077c",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fc2eed9862f01faa64ee93aa2655467b184bfe4f",
+                "reference": "fc2eed9862f01faa64ee93aa2655467b184bfe4f",
                 "shasum": ""
             },
             "require": {
@@ -4467,7 +4466,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-07T18:43:24+00:00"
+            "time": "2019-03-04T09:20:13+00:00"
         },
         {
             "name": "symfony/finder",
@@ -5806,12 +5805,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-uri.git",
-                "reference": "998ea438cc66efaa298c9527ff06895e56187737"
+                "reference": "b511ac0047a5b90ffa4903f8f3d66c326eab8ae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/998ea438cc66efaa298c9527ff06895e56187737",
-                "reference": "998ea438cc66efaa298c9527ff06895e56187737",
+                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/b511ac0047a5b90ffa4903f8f3d66c326eab8ae0",
+                "reference": "b511ac0047a5b90ffa4903f8f3d66c326eab8ae0",
                 "shasum": ""
             },
             "require": {
@@ -5826,8 +5825,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6.x-dev",
-                    "dev-develop": "2.7.x-dev"
+                    "dev-master": "2.7.x-dev",
+                    "dev-develop": "2.8.x-dev"
                 }
             },
             "autoload": {
@@ -5845,7 +5844,7 @@
                 "uri",
                 "zf"
             ],
-            "time": "2018-04-30T13:42:19+00:00"
+            "time": "2019-02-28T20:01:10+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -5924,7 +5923,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "nosto/php-sdk": 20,
         "magento/marketplace-tools": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acf0cb5892a9b86da27088cd87a490de",
+    "content-hash": "65c074d7997427bd9aaa1750e607637e",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "3.10.0",
+            "version": "dev-hotfix/3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "65dc7435d6036c6efc0add591bf3adbb60a4a3c4"
+                "reference": "bbbfee24edd577c48c03664009d6bf4f35b48e64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/65dc7435d6036c6efc0add591bf3adbb60a4a3c4",
-                "reference": "65dc7435d6036c6efc0add591bf3adbb60a4a3c4",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/bbbfee24edd577c48c03664009d6bf4f35b48e64",
+                "reference": "bbbfee24edd577c48c03664009d6bf4f35b48e64",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-02-19T13:16:14+00:00"
+            "time": "2019-02-25T09:46:34+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -59,12 +59,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "86b05c00817710c61074bbeb4dee44cd9dc126c6"
+                "reference": "926e43af9d12cbd2510889ca370dd2c5d1e26726"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/86b05c00817710c61074bbeb4dee44cd9dc126c6",
-                "reference": "86b05c00817710c61074bbeb4dee44cd9dc126c6",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/926e43af9d12cbd2510889ca370dd2c5d1e26726",
+                "reference": "926e43af9d12cbd2510889ca370dd2c5d1e26726",
                 "shasum": ""
             },
             "require": {
@@ -143,7 +143,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2019-02-10T23:20:21+00:00"
+            "time": "2019-02-25T03:36:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -395,12 +395,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "69745745b39bf6b24c8f88dc18b44980ee042e28"
+                "reference": "60f198c17d99728b0c1adb5b17e581fe274e34e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/69745745b39bf6b24c8f88dc18b44980ee042e28",
-                "reference": "69745745b39bf6b24c8f88dc18b44980ee042e28",
+                "url": "https://api.github.com/repos/composer/composer/zipball/60f198c17d99728b0c1adb5b17e581fe274e34e8",
+                "reference": "60f198c17d99728b0c1adb5b17e581fe274e34e8",
                 "shasum": ""
             },
             "require": {
@@ -467,7 +467,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-02-16T16:56:20+00:00"
+            "time": "2019-02-21T13:06:41+00:00"
         },
         {
             "name": "composer/semver",
@@ -3675,12 +3675,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "95a6897c75ecd816e8990aa5e9c671d76eea9ba7"
+                "reference": "eb9e39fb4c2034c31897cdb5f59498fc9126ddcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/95a6897c75ecd816e8990aa5e9c671d76eea9ba7",
-                "reference": "95a6897c75ecd816e8990aa5e9c671d76eea9ba7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/eb9e39fb4c2034c31897cdb5f59498fc9126ddcc",
+                "reference": "eb9e39fb4c2034c31897cdb5f59498fc9126ddcc",
                 "shasum": ""
             },
             "require": {
@@ -3692,7 +3692,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -3716,7 +3716,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-11T12:49:33+00:00"
+            "time": "2019-02-20T14:16:29+00:00"
         },
         {
             "name": "psr/container",
@@ -4174,12 +4174,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "b8f4eaed0131c05a18c595b7d9026d88e93508ae"
+                "reference": "3394ceea2ab7ed7477012c8cc2a273296dab7f48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/b8f4eaed0131c05a18c595b7d9026d88e93508ae",
-                "reference": "b8f4eaed0131c05a18c595b7d9026d88e93508ae",
+                "url": "https://api.github.com/repos/symfony/config/zipball/3394ceea2ab7ed7477012c8cc2a273296dab7f48",
+                "reference": "3394ceea2ab7ed7477012c8cc2a273296dab7f48",
                 "shasum": ""
             },
             "require": {
@@ -4229,7 +4229,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-17T09:56:33+00:00"
+            "time": "2019-02-23T15:22:31+00:00"
         },
         {
             "name": "symfony/console",
@@ -4475,12 +4475,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "7f64183e3ee0cda0644f31ed8f37f01e800af5e8"
+                "reference": "c2a5a99744e881c987e22faf443b74b661cada3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/7f64183e3ee0cda0644f31ed8f37f01e800af5e8",
-                "reference": "7f64183e3ee0cda0644f31ed8f37f01e800af5e8",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/c2a5a99744e881c987e22faf443b74b661cada3c",
+                "reference": "c2a5a99744e881c987e22faf443b74b661cada3c",
                 "shasum": ""
             },
             "require": {
@@ -4516,7 +4516,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T21:53:39+00:00"
+            "time": "2019-02-23T15:42:19+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -5924,6 +5924,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "nosto/php-sdk": 20,
         "magento/marketplace-tools": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfb281926bc833bef5236c5c256b2a1d",
+    "content-hash": "424d68bdc10e74b87ba4f69c068679c0",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "3.10.1",
+            "version": "3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "3b5bd711ec1288071a02483b0ead4b6eb70b4ecb"
+                "reference": "e193335c1b2d8cca05eae9ddf1efccb44e56ca8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/3b5bd711ec1288071a02483b0ead4b6eb70b4ecb",
-                "reference": "3b5bd711ec1288071a02483b0ead4b6eb70b4ecb",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/e193335c1b2d8cca05eae9ddf1efccb44e56ca8e",
+                "reference": "e193335c1b2d8cca05eae9ddf1efccb44e56ca8e",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-03-05T12:47:12+00:00"
+            "time": "2019-03-05T14:36:39+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -853,7 +853,8 @@
                 "url": "https://github.com/magento/marketplace-tools",
                 "reference": "origin/master"
             },
-            "type": "library"
+            "type": "library",
+            "time": "2017-04-06T01:16:20+00:00"
         },
         {
             "name": "magento/module-authorization",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add store domain and nosto account as header to product upsert and order confirmation calls. In this way data origin can be checked in Nosto backend. 

## Related Issue
closes #383

## Motivation and Context
Some merchant do have issues when creating a staging environment from production branch, copying nosto tokens and account. This leads to sending staging products/orders data to production in Nosto backend. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
