### PR TITLE
Save installation domain when creating or connecting Nosto account

### DIFF
--- a/Helper/Account.php
+++ b/Helper/Account.php
@@ -86,9 +86,10 @@ class Account extends AbstractHelper
     /**
      * Constructor.
      *
-     * @param Context $context the context.
-     * @param WriterInterface $appConfig the app config writer.
+     * @param Context $context
+     * @param WriterInterface $appConfig
      * @param Scope $nostoHelperScope
+     * @param Url $nostoHelperUrl
      */
     public function __construct(
         Context $context,
@@ -314,6 +315,6 @@ class Account extends AbstractHelper
     {
         $storedDomain = $store->getConfig(self::XML_PATH_DOMAIN);
         $realDomain = $this->nostoHelperUrl->getActiveDomain($store);
-        return ($realDomain == $storedDomain);
+        return ($realDomain === $storedDomain);
     }
 }

--- a/Helper/Account.php
+++ b/Helper/Account.php
@@ -361,7 +361,7 @@ class Account extends AbstractHelper
                     'nostoAccount' => $this->getAccountName($store),
                     'currentDomain' => $this->nostoHelperUrl->getActiveDomain($store),
                     'storedDomain' => $this->getStoreFrontDomain($store),
-                    'resetUrl' => $this->urlBuilder->getUrl('nosto/account/delete', ['store' => $store->getId()])
+                    'resetUrl' => $this->urlBuilder->getUrl('nosto/account/index', ['store' => $store->getId()])
                 ];
             }
         }

--- a/Model/Admin/Notification/Messages.php
+++ b/Model/Admin/Notification/Messages.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright (c) 2017, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2017 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\Admin\Notification;
+
+use Nosto\Tagging\Helper\Account as NostoHelperAccount;
+use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+use Magento\Framework\Notification\MessageInterface;
+
+class Messages implements MessageInterface
+{
+    private $nostoHelperScope;
+    private $nostoHelperAccount;
+    private $message;
+    private $storeNames;
+    private $display;
+
+    /**
+     * Messages constructor.
+     * @param NostoHelperAccount $nostoHelperAccount
+     * @param NostoHelperScope $nostoHelperScope
+     */
+    public function __construct(
+        NostoHelperAccount $nostoHelperAccount,
+        NostoHelperScope $nostoHelperScope
+    ) {
+        $this->nostoHelperScope = $nostoHelperScope;
+        $this->nostoHelperAccount = $nostoHelperAccount;
+    }
+
+    /**
+     * @return \Magento\Framework\Phrase|string
+     */
+    public function getText()
+    {
+        $message = __($this->message);
+        return $message;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentity()
+    {
+        return 'Nosto_Account_Notification';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDisplayed()
+    {
+        $stores = $this->nostoHelperScope->getStores();
+
+        foreach ($stores as $store) {
+
+            //Check if the store is connected to Nosto
+            if ($this->nostoHelperAccount->findAccount($store)) {
+                if ($this->nostoHelperAccount->isDomainValid($store) === false) {
+                    $this->storeNames[] = $store->getName();
+                    $this->display = true;
+                }
+            }
+        }
+
+        if ($this->display === true) {
+            $this->buildMessage();
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSeverity()
+    {
+        // From here you can change notification message type.
+        return MessageInterface::SEVERITY_CRITICAL;
+    }
+
+    /**
+     * Set the value of the message
+     */
+    private function buildMessage(){
+        $message = 'Nosto account is invalid for the stores: ';
+
+        foreach ($this->storeNames as $storeName) {
+            $message .= " * ".$storeName;
+        }
+
+        $message .= '. Please re-login';
+        $this->message = $message;
+    }
+
+}

--- a/Model/Admin/Notification/Messages.php
+++ b/Model/Admin/Notification/Messages.php
@@ -85,13 +85,11 @@ class Messages implements MessageInterface
         $stores = $this->nostoHelperScope->getStores();
 
         foreach ($stores as $store) {
-
             //Check if the store is connected to Nosto
             if ($this->nostoHelperAccount->findAccount($store)
                 && $this->nostoHelperAccount->isDomainValid($store) === false) {
                     $this->storeNames[] = $store->getName();
                     $this->display = true;
-
             }
         }
 
@@ -115,7 +113,8 @@ class Messages implements MessageInterface
     /**
      * Set the value of the message
      */
-    private function buildMessage(){
+    private function buildMessage()
+    {
         $message = 'Nosto account is invalid for the stores: ';
 
         foreach ($this->storeNames as $storeName) {
@@ -125,5 +124,4 @@ class Messages implements MessageInterface
         $message .= '. Please re-login';
         $this->message = $message;
     }
-
 }

--- a/Model/Admin/Notification/Messages.php
+++ b/Model/Admin/Notification/Messages.php
@@ -66,8 +66,7 @@ class Messages implements MessageInterface
      */
     public function getText()
     {
-        $message = __($this->message);
-        return $message;
+        return __($this->message);
     }
 
     /**
@@ -88,11 +87,11 @@ class Messages implements MessageInterface
         foreach ($stores as $store) {
 
             //Check if the store is connected to Nosto
-            if ($this->nostoHelperAccount->findAccount($store)) {
-                if ($this->nostoHelperAccount->isDomainValid($store) === false) {
+            if ($this->nostoHelperAccount->findAccount($store)
+                && $this->nostoHelperAccount->isDomainValid($store) === false) {
                     $this->storeNames[] = $store->getName();
                     $this->display = true;
-                }
+
             }
         }
 
@@ -120,7 +119,7 @@ class Messages implements MessageInterface
         $message = 'Nosto account is invalid for the stores: ';
 
         foreach ($this->storeNames as $storeName) {
-            $message .= " * ".$storeName;
+            $message .= ' * ' .$storeName;
         }
 
         $message .= '. Please re-login';

--- a/Model/Admin/Notification/Messages.php
+++ b/Model/Admin/Notification/Messages.php
@@ -74,7 +74,7 @@ class Messages implements MessageInterface
      */
     public function getIdentity()
     {
-        return 'Nosto_Account_Notification';
+        return md5('Nosto_Account_Notification');
     }
 
     /**

--- a/Model/Admin/Notification/Messages.php
+++ b/Model/Admin/Notification/Messages.php
@@ -39,13 +39,13 @@ namespace Nosto\Tagging\Model\Admin\Notification;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Magento\Framework\Notification\MessageInterface;
+use Magento\Framework\Phrase;
 
 class Messages implements MessageInterface
 {
     private $nostoHelperScope;
     private $nostoHelperAccount;
     private $message;
-    private $storeNames;
     private $display;
 
     /**
@@ -62,7 +62,7 @@ class Messages implements MessageInterface
     }
 
     /**
-     * @return \Magento\Framework\Phrase|string
+     * @return Phrase|string
      */
     public function getText()
     {
@@ -74,6 +74,7 @@ class Messages implements MessageInterface
      */
     public function getIdentity()
     {
+        //@codingStandardsIgnoreLine
         return md5('Nosto_Account_Notification');
     }
 
@@ -83,18 +84,19 @@ class Messages implements MessageInterface
     public function isDisplayed()
     {
         $stores = $this->nostoHelperScope->getStores();
+        $storeNames = [];
 
         foreach ($stores as $store) {
             //Check if the store is connected to Nosto
             if ($this->nostoHelperAccount->findAccount($store)
                 && $this->nostoHelperAccount->isDomainValid($store) === false) {
-                    $this->storeNames[] = $store->getName();
+                    $storeNames[] = $store->getName();
                     $this->display = true;
             }
         }
 
         if ($this->display === true) {
-            $this->buildMessage();
+            $this->buildMessage($storeNames);
             return true;
         }
 
@@ -106,22 +108,20 @@ class Messages implements MessageInterface
      */
     public function getSeverity()
     {
-        // From here you can change notification message type.
         return MessageInterface::SEVERITY_CRITICAL;
     }
 
     /**
      * Set the value of the message
      */
-    private function buildMessage()
+    private function buildMessage($storeNames)
     {
         $message = 'Nosto account is invalid for the stores: ';
 
-        foreach ($this->storeNames as $storeName) {
+        foreach ($storeNames as $storeName) {
             $message .= ' * ' .$storeName;
         }
 
-        $message .= '. Please re-login';
-        $this->message = $message;
+        $this->message = __($message);
     }
 }

--- a/Model/System/Message/Notification/InvalidAccount.php
+++ b/Model/System/Message/Notification/InvalidAccount.php
@@ -110,11 +110,13 @@ class InvalidAccount implements MessageInterface
         $message = '';
 
         foreach ($invalidStores as $store) {
-            $message .= 'It looks like you\'ve created Nosto account (<b>' . $store['nostoAccount'] . '</b>) for <b>' .$store['storedDomain']. '</b>';
-            $message .= 'and currently store\'s (<b>' . $store['storeName'] . '</b>) front page is <b>' . $store['currentDomain'] . '</b>.  ';
-            $message .= 'It is not possible to share Nosto accounts across multiple domains.';
-            $message .= 'Please reset the Nosto settings, and create a new Nosto account, or connect to an existing account. ';
-            $message .= '<a href=" ' . $store['resetUrl'] . ' ">Reset Nosto settings</a> </br></br>';
+            $message .= 'It looks like you\'ve created Nosto account (<b>' . $store['nostoAccount'] . '</b>) '
+                .'for <b>' .$store['storedDomain']. '</b> '
+                .'and currently store\'s (<b>' . $store['storeName'] . '</b>) front page is '
+                .'<b>' . $store['currentDomain'] . '</b>.  '
+                .'It is not possible to share Nosto accounts across multiple domains.'
+                .'Please reset the Nosto settings, and create a new Nosto account, or connect to an existing account. '
+                .'<a href=" ' . $store['resetUrl'] . ' ">Reset Nosto settings</a> </br></br>';
         }
 
         $this->message = __($message);

--- a/Model/System/Message/Notification/InvalidAccount.php
+++ b/Model/System/Message/Notification/InvalidAccount.php
@@ -103,7 +103,8 @@ class InvalidAccount implements MessageInterface
 
     /**
      * Set the value of the message
-     * @param array $storeNames
+     *
+     * @param array $invalidStores
      */
     private function buildMessage($invalidStores)
     {

--- a/Model/System/Message/Notification/InvalidAccount.php
+++ b/Model/System/Message/Notification/InvalidAccount.php
@@ -110,9 +110,11 @@ class InvalidAccount implements MessageInterface
         $message = '';
 
         foreach ($invalidStores as $store) {
-            $message .=  'It looks like you\'ve created Nosto account (<b>' . $store['nostoAccount'] . '</b>) for <b>' .$store['storedDomain']. '</b>
-                and currently store\'s (<b>' . $store['storeName'] . '</b>) front page is <b>' . $store['currentDomain'] . '</b>. It is not possible to share Nosto accounts across multiple domains. Please reset the Nosto settings, and create a new Nosto account, or connect to an existing account.	
-                <a href=" ' . $store['resetUrl'] . ' ">Reset Nosto settings</a> </br></br>';
+            $message .= 'It looks like you\'ve created Nosto account (<b>' . $store['nostoAccount'] . '</b>) for <b>' .$store['storedDomain']. '</b>';
+            $message .= 'and currently store\'s (<b>' . $store['storeName'] . '</b>) front page is <b>' . $store['currentDomain'] . '</b>.  ';
+            $message .= 'It is not possible to share Nosto accounts across multiple domains.';
+            $message .= 'Please reset the Nosto settings, and create a new Nosto account, or connect to an existing account. ';
+            $message .= '<a href=" ' . $store['resetUrl'] . ' ">Reset Nosto settings</a> </br></br>';
         }
 
         $this->message = __($message);

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<type name="Magento\Framework\Notification\MessageList">
+    <arguments>
+        <argument name="messages" xsi:type="array">
+            <item name="Nosto_Notification" xsi:type="string">Nosto\Tagging\Model\Admin\Notification\Messages</item>
+        </argument>
+    </arguments>
+</type>
+
+</config>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,4 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2017, Nosto Solutions Ltd
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification,
+  ~ are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice,
+  ~ this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice,
+  ~ this list of conditions and the following disclaimer in the documentation
+  ~ and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors
+  ~ may be used to endorse or promote products derived from this software without
+  ~ specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+  ~ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ~
+  ~ @author Nosto Solutions Ltd <contact@nosto.com>
+  ~ @copyright 2017 Nosto Solutions Ltd
+  ~ @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+  ~
+  -->
+
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 <type name="Magento\Framework\Notification\MessageList">
     <arguments>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -38,7 +38,7 @@
 <type name="Magento\Framework\Notification\MessageList">
     <arguments>
         <argument name="messages" xsi:type="array">
-            <item name="Nosto_Notification" xsi:type="string">Nosto\Tagging\Model\Admin\Notification\Messages</item>
+            <item name="Nosto_Notification" xsi:type="string">Nosto\Tagging\Model\System\Message\Notification\InvalidAccount</item>
         </argument>
     </arguments>
 </type>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Store the storeview domain in database when installing or connecting Nosto account.
Display system notification if the domain from the database does not match the real storeview domain. 

## Related Issue
closes 
#382
#384

## Motivation and Context
Sometimes merchant create staging environment by copying the production one. This leads to having the same Nosto account for both environments. 

## How Has This Been Tested?
Tested manually by creating account. 
Changed domain and checked if notification was working properly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
