### PR TITLE
Revert "Hotfix 3.2.1 - Fix empty minPrice array problem when bundle product has no options"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
-### 3.2.1
-* Fix issue calculating bundle product price with no options
-
 ### 3.2.0
 * Disable price variation when multicurrency is enabled
 * Skip product attributes that contains arrays with non-scalar values

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -273,11 +273,8 @@ class Price extends AbstractHelper
                     $requiredMinPrices[] = $selectionMinPrice;
                 }
             }
-            // In case there the product has no options at all
-            $minPrice = !empty($minPrices) ? min($minPrices) : 0;
-
             // If all products are optional use the price for the cheapest option
-            $price = $allOptional ? $minPrice : array_sum($requiredMinPrices);
+            $price = $allOptional ? min($minPrices) : array_sum($requiredMinPrices);
         }
         return $price;
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.2.1",
+  "version": "3.2.0",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.2.1"/>
+    <module name="Nosto_Tagging" setup_version="3.2.0"/>
 </config>


### PR DESCRIPTION
Reverts Nosto/nosto-magento2#406