### PR TITLE
Hotfix 3.2.1 - Fix empty minPrice array problem when bundle product has no options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.2.1
+* Fix issue calculating bundle product price with no options
+
 ### 3.2.0
 * Disable price variation when multicurrency is enabled
 * Skip product attributes that contains arrays with non-scalar values

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -273,8 +273,11 @@ class Price extends AbstractHelper
                     $requiredMinPrices[] = $selectionMinPrice;
                 }
             }
+            // In case there the product has no options at all
+            $minPrice = !empty($minPrices) ? min($minPrices) : 0;
+
             // If all products are optional use the price for the cheapest option
-            $price = $allOptional ? min($minPrices) : array_sum($requiredMinPrices);
+            $price = $allOptional ? $minPrice : array_sum($requiredMinPrices);
         }
         return $price;
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.2.0"/>
+    <module name="Nosto_Tagging" setup_version="3.2.1"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When calculating the price of a bundle product, it fails if the product has no options and $finalPrice is set to false
 
## Related Issue
closes #405

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
