### PR TITLE
Hotfix - 3.2.2  Insert missing storefront domain in db when upgrading module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.2.2
+* Fix issue with missing storefront domain when upgrading modue
+
 ### 3.2.1
 * Fix issue calculating bundle product price with no options
 

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright (c) 2017, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2017 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Setup;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Nosto\Tagging\Helper\Account as NostoHelperAccount;
+use Nosto\Tagging\Helper\Url as NostoHelperUrl;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class UpgradeData implements UpgradeDataInterface
+{
+    /** @var NostoHelperAccount */
+    private $nostoHelperAccount;
+
+    /** @var NostoHelperUrl */
+    private $nostoHelperUrl;
+
+    /** @var WriterInterface */
+    private $config;
+
+    /**
+     * UpgradeData constructor.
+     * @param NostoHelperAccount $nostoHelperAccount
+     * @param NostoHelperUrl $nostoHelperUrl
+     * @param WriterInterface $appConfig
+     */
+    public function __construct(
+        NostoHelperAccount $nostoHelperAccount,
+        NostoHelperUrl $nostoHelperUrl,
+        WriterInterface $appConfig
+    ) {
+        $this->nostoHelperAccount = $nostoHelperAccount;
+        $this->nostoHelperUrl = $nostoHelperUrl;
+        $this->config = $appConfig;
+    }
+
+    /**
+     * @param ModuleDataSetupInterface $setup
+     * @param ModuleContextInterface $context
+     */
+    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context) // @codingStandardsIgnoreLine
+    {
+        if (version_compare($context->getVersion(), '3.1.0', '>=')) {
+            $this->insertStoreDomain();
+        }
+    }
+
+    /**
+     * Insert store domain when missing in database
+     */
+    private function insertStoreDomain()
+    {
+        $stores = $this->nostoHelperAccount->getStoresWithNosto();
+        foreach ($stores as $store) {
+            if ($this->nostoHelperAccount->getStoreFrontDomain($store) === null) {
+                // @codingStandardsIgnoreLine
+                $this->config->save(
+                    NostoHelperAccount::XML_PATH_DOMAIN,
+                    $this->nostoHelperUrl->getActiveDomain($store),
+                    ScopeInterface::SCOPE_STORE,
+                    $store->getId()
+                );
+            }
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.2.1"/>
+    <module name="Nosto_Tagging" setup_version="3.2.2"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Insert missing storefront domain for nosto account on module upgrade.

## Related Issue
closes #409

## Motivation and Context
When merchant upgraded the module, the store domain was missing in the database.

## How Has This Been Tested?
Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
