### PR TITLE
Clear DI in account helper class

### DIFF
--- a/Helper/Account.php
+++ b/Helper/Account.php
@@ -51,7 +51,6 @@ use Nosto\Types\Signup\AccountInterface;
 use Nosto\Object\Signup\Account as NostoSignupAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Helper\Url as NostoHelperUrl;
-use Magento\Framework\UrlInterface;
 
 /**
  * NostoHelperAccount helper class for common tasks related to Nosto accounts.
@@ -86,8 +85,7 @@ class Account extends AbstractHelper
     private $urlBuilder;
 
     /**
-     * Constructor.
-     *
+     * Account constructor.
      * @param Context $context
      * @param WriterInterface $appConfig
      * @param Scope $nostoHelperScope
@@ -97,8 +95,7 @@ class Account extends AbstractHelper
         Context $context,
         WriterInterface $appConfig,
         NostoHelperScope $nostoHelperScope,
-        NostoHelperUrl $nostoHelperUrl,
-        UrlInterface $urlBuilder
+        NostoHelperUrl $nostoHelperUrl
     ) {
         parent::__construct($context);
 
@@ -107,7 +104,7 @@ class Account extends AbstractHelper
         $this->logger = $context->getLogger();
         $this->nostoHelperScope = $nostoHelperScope;
         $this->nostoHelperUrl = $nostoHelperUrl;
-        $this->urlBuilder = $urlBuilder;
+        $this->urlBuilder = $this->_urlBuilder;
     }
 
     /**

--- a/Helper/Account.php
+++ b/Helper/Account.php
@@ -104,7 +104,7 @@ class Account extends AbstractHelper
         $this->logger = $context->getLogger();
         $this->nostoHelperScope = $nostoHelperScope;
         $this->nostoHelperUrl = $nostoHelperUrl;
-        $this->urlBuilder = $this->_urlBuilder;
+        $this->urlBuilder = $context->getUrlBuilder();
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Error is thrown while executing `bin/magento setup:di:compile` because `UrlInterface` already exists in context object

## Related Issue
closes #412

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
