### PR TITLE
Hotfix 3.2.4 - Add to cart use product super attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.2.4
+* Fix an issue with configurable products that were added to cart had no link or image.
+
 ### 3.2.3
 * Fix issue with scope when saving the domain
 
 ### 3.2.2
-* Fix issue with missing storefront domain when upgrading modue
+* Fix issue with missing storefront domain when upgrading module
 
 ### 3.2.1
 * Fix issue calculating bundle product price with no options

--- a/Controller/Checkout/Cart/Add.php
+++ b/Controller/Checkout/Cart/Add.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright (c) 2017, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2017 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Controller\Checkout\Cart;
+
+use Magento\Checkout\Controller\Cart\Add as MageAdd;
+
+class Add
+{
+    public function aroundExecute(MageAdd $add, callable $proceed)
+    {
+        $returnValue = $proceed();
+        return $returnValue;
+    }
+}

--- a/Controller/Checkout/Cart/Add.php
+++ b/Controller/Checkout/Cart/Add.php
@@ -106,13 +106,13 @@ class Add
             $skuProduct = $this->initProduct($skuId);
             if ($skuProduct instanceof Product) {
                 $attributeOptions = $this->getAttributeOptions($product, $skuProduct, $parentType);
+                if (!empty($attributeOptions)) {
+                    $params['super_attribute'] = $attributeOptions;
+                    $add->getRequest()->setParams($params);
+                }
             }
         }
 
-        if (!empty($attributeOptions)) {
-            $params['super_attribute'] = $attributeOptions;
-            $add->getRequest()->setParams($params);
-        }
         return $proceed();
     }
 

--- a/Controller/Checkout/Cart/Add.php
+++ b/Controller/Checkout/Cart/Add.php
@@ -49,8 +49,6 @@ use Magento\Store\Model\StoreManager;
  * Class Add
  * Implements around method to Magento's native add to cart controller.
  * Modify the request to add a super_attribute key if it is missing.
- *
- * @package Nosto\Tagging\Controller\Checkout\Cart
  */
 class Add
 {

--- a/Controller/Checkout/Cart/Add.php
+++ b/Controller/Checkout/Cart/Add.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2017, Nosto Solutions Ltd
+ * Copyright (c) 2019, Nosto Solutions Ltd
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -29,7 +29,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * @author Nosto Solutions Ltd <contact@nosto.com>
- * @copyright 2017 Nosto Solutions Ltd
+ * @copyright 2019 Nosto Solutions Ltd
  * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
  *
  */
@@ -47,6 +47,9 @@ use Magento\Store\Model\StoreManager;
 
 /**
  * Class Add
+ * Implements around method to Magento's native add to cart controller.
+ * Modify the request to add a super_attribute key if it is missing.
+ *
  * @package Nosto\Tagging\Controller\Checkout\Cart
  */
 class Add
@@ -103,7 +106,9 @@ class Add
         $skuId = $add->getRequest()->getParam('sku');
         if ($parentType instanceof ConfigurableType && !empty($skuId)) {
             $skuProduct = $this->initProduct($skuId);
-            $attributeOptions = $this->getAttributeOptions($product, $skuProduct, $parentType);
+            if ($skuProduct instanceof Product) {
+                $attributeOptions = $this->getAttributeOptions($product, $skuProduct, $parentType);
+            }
         }
 
         if (!empty($attributeOptions)) {
@@ -144,19 +149,19 @@ class Add
      * Initialize product instance from request data
      *
      * @param $productId
-     * @return bool|ProductInterface|Product
+     * @return null|ProductInterface|Product
      */
     private function initProduct($productId)
     {
         try {
             $store = $this->storeManager->getStore();
             if (!$store) {
-                return false;
+                return null;
             }
             $storeId = $store->getId();
             return $this->productRepository->getById($productId, false, $storeId);
         } catch (\Exception $e) {
-            return false;
+            return null;
         }
     }
 }

--- a/Controller/Checkout/Cart/Add.php
+++ b/Controller/Checkout/Cart/Add.php
@@ -37,6 +37,8 @@
 namespace Nosto\Tagging\Controller\Checkout\Cart;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResourceModel;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Checkout\Controller\Cart\Add as MageAdd;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
@@ -85,6 +87,7 @@ class Add
         }
         $productId = $params['product'];
         $skuId = $add->getRequest()->getParam('sku');
+        /** @var Product $product */
         $product = $this->initProduct($productId);
         $parentType = false;
         if ($product) {
@@ -96,7 +99,10 @@ class Add
             $configurableAttributes = $parentType->getConfigurableAttributesAsArray($product);
             foreach ($configurableAttributes as $configurableAttribute) {
                 $attributeCode = $configurableAttribute['attribute_code'];
-                $attribute = $skuProduct->getResource()->getAttribute($attributeCode);
+                /** @var Product $skuProduct */
+                $skuResource = $skuProduct->getResource();
+                /** @var ProductResourceModel $skuResource */
+                $attribute = $skuResource->getAttribute($attributeCode);
                 if ($attribute instanceof MageAttribute) {
                     $attributeId = $attribute->getId();
                     $attributeValueId = $skuProduct->getData($attributeCode);

--- a/Controller/Checkout/Cart/Add.php
+++ b/Controller/Checkout/Cart/Add.php
@@ -121,13 +121,13 @@ class Add
      * @param ConfigurableType $configurableType
      * @return array
      */
-    protected function getAttributeOptions(Product $product, Product $skuProduct, ConfigurableType $configurableType)
+    private function getAttributeOptions(Product $product, Product $skuProduct, ConfigurableType $configurableType)
     {
         $configurableAttributes = $configurableType->getConfigurableAttributesAsArray($product);
         $attributeOptions = [];
+        $skuResource = $this->productResourceModel->load($skuProduct, $skuProduct->getId());
         foreach ($configurableAttributes as $configurableAttribute) {
             $attributeCode = $configurableAttribute['attribute_code'];
-            $skuResource = $this->productResourceModel->load($skuProduct, $skuProduct->getId());
             $attribute = $skuResource->getAttribute($attributeCode);
             if ($attribute instanceof MageAttribute) {
                 $attributeId = $attribute->getId();
@@ -146,7 +146,7 @@ class Add
      * @param $productId
      * @return bool|ProductInterface|Product
      */
-    protected function initProduct($productId)
+    private function initProduct($productId)
     {
         try {
             $store = $this->storeManager->getStore();
@@ -159,5 +159,4 @@ class Add
             return false;
         }
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -58,4 +58,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Checkout\Controller\Cart\Add">
+        <plugin name="nostoAddToCart" type="Nosto\Tagging\Controller\Checkout\Cart\Add" sortOrder="1" />
+    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -58,7 +58,4 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Checkout\Controller\Cart\Add">
-        <plugin name="nostoAddToCart" type="Nosto\Tagging\Controller\Checkout\Cart\Add" sortOrder="1" />
-    </type>
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -45,4 +45,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Checkout\Controller\Cart\Add">
+        <plugin name="nostoAddToCart" type="Nosto\Tagging\Controller\Checkout\Cart\Add" sortOrder="1" />
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.2.3"/>
+    <module name="Nosto_Tagging" setup_version="3.2.4"/>
 </config>

--- a/view/frontend/web/js/recobuy.js
+++ b/view/frontend/web/js/recobuy.js
@@ -102,7 +102,12 @@ define([
             relatedProductsField.setAttribute("value", product.related_product);
             form.append(relatedProductsField);
         } else {
-            form.find('input[name="product"]').val(product.skuId);
+            form.find('input[name="product"]').val(product.productId);
+            var productSku = document.createElement("input");
+            productSku.setAttribute("type", "hidden");
+            productSku.setAttribute("name", 'sku');
+            productSku.setAttribute("value", product.skuId);
+            form.append(productSku);
         }
         form.find('input[name="qty"]').val(quantity);
         form.catalogAddToCart('ajaxSubmit', form);

--- a/view/frontend/web/js/recobuy.js
+++ b/view/frontend/web/js/recobuy.js
@@ -56,23 +56,9 @@ define([
     // skuId is optional for simple products.
     Recobuy.addMultipleProductsToCart = function (products, element) {
         if (products.constructor === Array) {
-            var productArray = [];
-            var skus = [];
             products.forEach(function (productObj) {
-                if (productObj.skuId){
-                    skus.push(productObj.skuId);
-                } else {
-                    skus.push(productObj.productId);
-                }
-                if (productObj.productId) {
-                    productArray.push(productObj.productId);
-                }
+                Recobuy.addSkuToCart(productObj, element, 1);
             });
-            var productData = {
-                "productId" : productArray,
-                "related_product" : skus
-            };
-            Recobuy.addSkuToCart(productData, element, 1);
         }
     };
 
@@ -83,32 +69,18 @@ define([
             var slotId = this.resolveContextSlotId(element);
             if (slotId) {
                 nostojs(function (api) {
-                    if (product.hasOwnProperty('related_product') && product.productId.constructor === Array) {
-                        product.productId.forEach(function (singleProductId) {
-                            api.recommendedProductAddedToCart(singleProductId, slotId);
-                        });
-                    } else {
-                        api.recommendedProductAddedToCart(product.productId, slotId);
-                    }
+                    api.recommendedProductAddedToCart(product.productId, slotId);
                 });
             }
         }
-        if (product.hasOwnProperty('related_product')) {
-            form.find('input[name="product"]').val(product.related_product.pop());
-            // Add array of related products
-            var relatedProductsField = document.createElement("input");
-            relatedProductsField.setAttribute("type", "hidden");
-            relatedProductsField.setAttribute("name", 'related_product');
-            relatedProductsField.setAttribute("value", product.related_product);
-            form.append(relatedProductsField);
-        } else {
-            form.find('input[name="product"]').val(product.productId);
-            var productSku = document.createElement("input");
-            productSku.setAttribute("type", "hidden");
-            productSku.setAttribute("name", 'sku');
-            productSku.setAttribute("value", product.skuId);
-            form.append(productSku);
-        }
+
+        form.find('input[name="product"]').val(product.productId);
+        var productSku = document.createElement("input");
+        productSku.setAttribute("type", "hidden");
+        productSku.setAttribute("name", 'sku');
+        productSku.setAttribute("value", product.skuId);
+        form.append(productSku);
+
         form.find('input[name="qty"]').val(quantity);
         form.catalogAddToCart('ajaxSubmit', form);
     };


### PR DESCRIPTION
## Description
Fixes an issue where a product added to cart was an SKU product, instead of the parent configurable product with SKU super_attributes.

## Related Issue
Fixes #423 

## Motivation and Context
Some SKU added to cart had no links to the parent product and sometimes nor images.

## How Has This Been Tested?
Tested locally with 

```
Nosto.addSkuToCart({'productId': '68', 'skuId': '56'}, this);
```

## Documentation:
Not changed.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
