### PR TITLE
Send unmatched orders

### DIFF
--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -114,6 +114,7 @@ class Save implements ObserverInterface
      * @param Observer $observer
      * @return void
      * @suppress PhanDeprecatedFunction
+     * @suppress PhanTypeMismatchArgument
      */
     public function execute(Observer $observer)
     {
@@ -138,11 +139,13 @@ class Save implements ObserverInterface
                 $nostoCustomer = $this->customerRepository
                     ->getOneByQuoteId($quoteId);
                 if ($nostoCustomer instanceof NostoCustomer === false) {
-                    return;
+                    $nostoCustomerId = null;
+                } else {
+                    $nostoCustomerId = $nostoCustomer->getNostoId();
                 }
                 $orderService = new OrderConfirm($nostoAccount, $this->nostoHelperUrl->getActiveDomain($store));
                 try {
-                    $orderService->send($nostoOrder, $nostoCustomer->getNostoId());
+                    $orderService->send($nostoOrder, $nostoCustomerId);
                 } catch (\Exception $e) {
                     $this->logger->error(
                         sprintf(

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -138,9 +138,8 @@ class Save implements ObserverInterface
                 /** @var NostoCustomer $nostoCustomer */
                 $nostoCustomer = $this->customerRepository
                     ->getOneByQuoteId($quoteId);
-                if ($nostoCustomer instanceof NostoCustomer === false) {
-                    $nostoCustomerId = null;
-                } else {
+                $nostoCustomerId = null;
+                if ($nostoCustomer instanceof NostoCustomer) {
                     $nostoCustomerId = $nostoCustomer->getNostoId();
                 }
                 $orderService = new OrderConfirm($nostoAccount, $this->nostoHelperUrl->getActiveDomain($store));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Send unmatched orders through API. This was blocked because the method would just return if nostoCustomer was not found. 

## Related Issue
closes #425 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
