### PR TITLE
Fire custom nosto event when order is created

### DIFF
--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -69,6 +69,7 @@ class Save implements ObserverInterface
     private $nostoHelperScope;
     private $indexer;
     private $nostoHelperUrl;
+    private static $sent = [];
 
     /** @noinspection PhpUndefinedClassInspection */
     /**
@@ -127,6 +128,11 @@ class Save implements ObserverInterface
             /* @var Order $order */
             /** @noinspection PhpUndefinedMethodInspection */
             $order = $observer->getOrder();
+
+            //Check if order has been sent once
+            if (in_array($order->getId(), self::$sent)) {
+                return;
+            }
             $store = $order->getStore();
             $nostoOrder = $this->nostoOrderBuilder->build($order);
             $nostoAccount = $this->nostoHelperAccount->findAccount(
@@ -155,6 +161,7 @@ class Save implements ObserverInterface
                     );
                 }
                 $this->handleInventoryLevelUpdate($nostoOrder);
+                self::$sent[] = $order->getId();
             }
         }
     }

--- a/Plugin/Sales/OrderRepository.php
+++ b/Plugin/Sales/OrderRepository.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Plugin\Sales;
+
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
+class OrderRepository
+{
+    /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    /**
+     * OrderRepository constructor.
+     * @param ManagerInterface $eventManager
+     */
+    public function __construct(
+        ManagerInterface $eventManager
+    ) {
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * @param \Magento\Sales\Api\OrderRepositoryInterface $subject
+     * @param $order
+     * @return mixed
+     */
+    public function afterSave(OrderRepositoryInterface $subject, $order)
+    {
+        $this->eventManager->dispatch('nosto_sales_save_after', ['order' => $order]);
+        return $order;
+    }
+}

--- a/Plugin/Sales/OrderRepository.php
+++ b/Plugin/Sales/OrderRepository.php
@@ -63,7 +63,7 @@ class OrderRepository
      * @param OrderInterface|Order $order
      * @return OrderInterface
      */
-    public function afterSave(OrderRepositoryInterface $subject, $order)
+    public function afterSave(OrderRepositoryInterface $subject, OrderInterface $order)
     {
         $this->eventManager->dispatch('nosto_sales_save_after', ['order' => $order]);
         return $order;

--- a/Plugin/Sales/OrderRepository.php
+++ b/Plugin/Sales/OrderRepository.php
@@ -38,6 +38,8 @@ namespace Nosto\Tagging\Plugin\Sales;
 
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order;
 
 class OrderRepository
 {
@@ -57,9 +59,9 @@ class OrderRepository
     }
 
     /**
-     * @param \Magento\Sales\Api\OrderRepositoryInterface $subject
-     * @param $order
-     * @return mixed
+     * @param OrderRepositoryInterface $subject
+     * @param OrderInterface|Order $order
+     * @return OrderInterface
      */
     public function afterSave(OrderRepositoryInterface $subject, $order)
     {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -58,4 +58,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Sales\Api\OrderRepositoryInterface">
+        <plugin name="order_repository_nosto" type="Nosto\Tagging\Plugin\Sales\OrderRepository" />
+    </type>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="sales_order_save_commit_after">
+    <event name="nosto_sales_save_after">
         <observer name="nosto_order_confirmation" instance="Nosto\Tagging\Observer\Order\Save"/>
     </event>
     <event name="review_save_commit_after">

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -37,6 +37,9 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="sales_order_save_commit_after">
+        <observer name="nosto_order_confirmation" instance="Nosto\Tagging\Observer\Order\Save"/>
+    </event>
     <event name="nosto_sales_save_after">
         <observer name="nosto_order_confirmation" instance="Nosto\Tagging\Observer\Order\Save"/>
     </event>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Solved by creating a plugin and firing a new event called `nosto_sales_save_after` after the order has been saved. The order observer will listen to both events.

## Related Issue
closes #427

## Motivation and Context
Event `sales_order_save_commit_after` does not trigger when customer is not logged in. So we skip the order and do not send the data.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
