### PR TITLE
Define dependencies as proxies 

### DIFF
--- a/Console/Command/NostoAccountConnectCommand.php
+++ b/Console/Command/NostoAccountConnectCommand.php
@@ -45,7 +45,6 @@ use Nosto\Tagging\Helper\Account as NostoAccountHelper;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Object\Signup\Account as NostoSignupAccount;
 use Nosto\Request\Api\Token;
-use Nosto\NostoException;
 
 class NostoAccountConnectCommand extends Command
 {
@@ -70,14 +69,14 @@ class NostoAccountConnectCommand extends Command
 
     /**
      * NostoConfigConnectCommand constructor.
-     * @param NostoAccountHelper $accountHelper
+     * @param NostoAccountHelper $nostoAccountHelper
      * @param NostoHelperScope $nostoHelperScope
      */
     public function __construct(
-        NostoAccountHelper $accountHelper,
+        NostoAccountHelper $nostoAccountHelper,
         NostoHelperScope $nostoHelperScope
     ) {
-        $this->accountHelper = $accountHelper;
+        $this->accountHelper = $nostoAccountHelper;
         $this->nostoHelperScope = $nostoHelperScope;
         parent::__construct();
     }

--- a/Console/Command/NostoAccountConnectCommand.php
+++ b/Console/Command/NostoAccountConnectCommand.php
@@ -41,7 +41,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Nosto\Tagging\Helper\Account as NostoAccountHelper;
+use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Object\Signup\Account as NostoSignupAccount;
 use Nosto\Request\Api\Token;
@@ -53,9 +53,9 @@ class NostoAccountConnectCommand extends Command
     const SCOPE_CODE = 'scope-code';
 
     /*
-     * @var NostoAccountHelper
+     * @var NostoHelperAccount
      */
-    private $accountHelper;
+    private $nostoHelperAccount;
 
     /**
      * @var NostoHelperScope
@@ -69,14 +69,14 @@ class NostoAccountConnectCommand extends Command
 
     /**
      * NostoConfigConnectCommand constructor.
-     * @param NostoAccountHelper $nostoAccountHelper
+     * @param NostoHelperAccount $nostoHelperAccount
      * @param NostoHelperScope $nostoHelperScope
      */
     public function __construct(
-        NostoAccountHelper $nostoAccountHelper,
+        NostoHelperAccount $nostoHelperAccount,
         NostoHelperScope $nostoHelperScope
     ) {
-        $this->accountHelper = $nostoAccountHelper;
+        $this->nostoHelperAccount = $nostoHelperAccount;
         $this->nostoHelperScope = $nostoHelperScope;
         parent::__construct();
     }
@@ -167,8 +167,8 @@ class NostoAccountConnectCommand extends Command
             $io->error('Store not found. Check your input.');
             return false;
         }
-        $storeAccountId = $store->getConfig(NostoAccountHelper::XML_PATH_ACCOUNT);
-        $account = $this->accountHelper->findAccount($store);
+        $storeAccountId = $store->getConfig(NostoHelperAccount::XML_PATH_ACCOUNT);
+        $account = $this->nostoHelperAccount->findAccount($store);
         if ($account && $storeAccountId === $accountId) {
             // If the script is non-interactive, do not ask for confirmation
             $confirmOverride = $this->isInteractive ?
@@ -179,13 +179,13 @@ class NostoAccountConnectCommand extends Command
                true;
             if ($confirmOverride) {
                 $account->setTokens($tokens);
-                return $this->accountHelper->saveAccount($account, $store);
+                return $this->nostoHelperAccount->saveAccount($account, $store);
             }
         } else {
             $io->note('Local account not found. Saving local account...');
             $account = new NostoSignupAccount($accountId);
             $account->setTokens($tokens);
-            return $this->accountHelper->saveAccount($account, $store);
+            return $this->nostoHelperAccount->saveAccount($account, $store);
         }
     }
 

--- a/Console/Command/NostoAccountRemoveCommand.php
+++ b/Console/Command/NostoAccountRemoveCommand.php
@@ -41,26 +41,31 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Nosto\Tagging\Helper\Account as NostoAccountHelper;
-use Nosto\Tagging\Helper\Scope as NostoScopeHelper;
+use Nosto\Tagging\Helper\Account as NostoHelperAccount;
+use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+use Nosto\Tagging\Helper\Cache as NostoHelperCache;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Magento\Framework\App\Config\Storage\WriterInterface;
-use Nosto\Tagging\Helper\Cache as NostoHelperCache;
 
 class NostoAccountRemoveCommand extends Command
 {
     const SCOPE_CODE = 'scope-code';
 
     /*
-     * @var NostoAccountHelper
+     * @var NostoHelperAccount
      */
-    private $nostoAccountHelper;
+    private $nostoHelperAccount;
 
     /**
      * @var NostoHelperScope
      */
-    private $nostoScopeHelper;
+    private $nostoHelperScope;
+
+    /**
+     * @var NostoHelperCache
+     */
+    private $nostoHelperCache;
 
     /**
      * @var bool
@@ -73,27 +78,22 @@ class NostoAccountRemoveCommand extends Command
     private $config;
 
     /**
-     * @var NostoHelperCache
-     */
-    private $nostoHelperCache;
-
-    /**
      * NostoAccountRemoveCommand constructor.
-     * @param NostoAccountHelper $nostoAccountHelper
-     * @param NostoScopeHelper $nostoScopeHelper
+     * @param NostoHelperAccount $nostoHelperAccount
+     * @param NostoHelperScope $nostoHelperScope
      * @param WriterInterface $appConfig
-     * @param NostoHelperCache $nostoCacheHelper
+     * @param NostoHelperCache $nostoHelperCache
      */
     public function __construct(
-        NostoAccountHelper $nostoAccountHelper,
-        NostoScopeHelper $nostoScopeHelper,
+        NostoHelperAccount $nostoHelperAccount,
+        NostoHelperScope $nostoHelperScope,
         WriterInterface $appConfig,
-        NostoHelperCache $nostoCacheHelper
+        NostoHelperCache $nostoHelperCache
     ) {
-        $this->nostoAccountHelper = $nostoAccountHelper;
-        $this->nostoScopeHelper  = $nostoScopeHelper;
+        $this->nostoHelperAccount = $nostoHelperAccount;
+        $this->nostoHelperScope = $nostoHelperScope;
         $this->config = $appConfig;
-        $this->nostoHelperCache = $nostoCacheHelper;
+        $this->nostoHelperCache = $nostoHelperCache;
         parent::__construct();
     }
 
@@ -141,12 +141,12 @@ class NostoAccountRemoveCommand extends Command
      */
     private function removeNostoAccount(SymfonyStyle $io, $scopeCode)
     {
-        $store = $this->nostoScopeHelper->getStoreByCode($scopeCode);
+        $store = $this->nostoHelperScope->getStoreByCode($scopeCode);
         if (!$store) {
             $io->error('Store not found. Check your input.');
             return false;
         }
-        if (!$this->nostoAccountHelper->nostoInstalledAndEnabled($store)) {
+        if (!$this->nostoHelperAccount->nostoInstalledAndEnabled($store)) {
             $io->warning('Store is not connected with any Nosto account.');
             return false;
         }
@@ -181,12 +181,12 @@ class NostoAccountRemoveCommand extends Command
         }
 
         $this->config->delete(
-            NostoAccountHelper::XML_PATH_ACCOUNT,
+            NostoHelperAccount::XML_PATH_ACCOUNT,
             ScopeInterface::SCOPE_STORES,
             $store->getId()
         );
         $this->config->delete(
-            NostoAccountHelper::XML_PATH_TOKENS,
+            NostoHelperAccount::XML_PATH_TOKENS,
             ScopeInterface::SCOPE_STORES,
             $store->getId()
         );

--- a/Console/Command/NostoAccountRemoveCommand.php
+++ b/Console/Command/NostoAccountRemoveCommand.php
@@ -82,18 +82,18 @@ class NostoAccountRemoveCommand extends Command
      * @param NostoAccountHelper $nostoAccountHelper
      * @param NostoScopeHelper $nostoScopeHelper
      * @param WriterInterface $appConfig
-     * @param NostoHelperCache $nostoHelperCache
+     * @param NostoHelperCache $nostoCacheHelper
      */
     public function __construct(
         NostoAccountHelper $nostoAccountHelper,
         NostoScopeHelper $nostoScopeHelper,
         WriterInterface $appConfig,
-        NostoHelperCache $nostoHelperCache
+        NostoHelperCache $nostoCacheHelper
     ) {
         $this->nostoAccountHelper = $nostoAccountHelper;
         $this->nostoScopeHelper  = $nostoScopeHelper;
         $this->config = $appConfig;
-        $this->nostoHelperCache = $nostoHelperCache;
+        $this->nostoHelperCache = $nostoCacheHelper;
         parent::__construct();
     }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -43,15 +43,16 @@
     </type>
     <type name="Nosto\Tagging\Console\Command\NostoAccountConnectCommand">
         <arguments>
-            <argument name="accountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+            <argument name="nostoAccountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
             <argument name="nostoHelperScope" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Console\Command\NostoAccountRemoveCommand">
         <arguments>
-            <argument name="accountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
-            <argument name="nostoHelperScope" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
-            <argument name="nostoHelperCache" xsi:type="object">Nosto\Tagging\Helper\Cache\Proxy</argument>
+            <argument name="nostoAccountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+            <argument name="nostoScopeHelper" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
+            <argument name="appConfig" xsi:type="object">Magento\Framework\App\Config\Storage\Writer\Proxy</argument>
+            <argument name="nostoCacheHelper" xsi:type="object">Nosto\Tagging\Helper\Cache\Proxy</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Logger\Logger">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -43,16 +43,16 @@
     </type>
     <type name="Nosto\Tagging\Console\Command\NostoAccountConnectCommand">
         <arguments>
-            <argument name="nostoAccountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+            <argument name="nostoHelperAccount" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
             <argument name="nostoHelperScope" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Console\Command\NostoAccountRemoveCommand">
         <arguments>
-            <argument name="nostoAccountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
-            <argument name="nostoScopeHelper" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
+            <argument name="nostoHelperAccount" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+            <argument name="nostoHelperScope" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
             <argument name="appConfig" xsi:type="object">Magento\Framework\App\Config\Storage\Writer\Proxy</argument>
-            <argument name="nostoCacheHelper" xsi:type="object">Nosto\Tagging\Helper\Cache\Proxy</argument>
+            <argument name="nostoHelperCache" xsi:type="object">Nosto\Tagging\Helper\Cache\Proxy</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Logger\Logger">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -41,6 +41,19 @@
     <type name="Magento\Catalog\Model\ResourceModel\Product">
         <plugin name="nostoProductIndexer" type="Nosto\Tagging\Model\Indexer\Product\Observer"/>
     </type>
+    <type name="Nosto\Tagging\Console\Command\NostoAccountConnectCommand">
+        <arguments>
+            <argument name="accountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+            <argument name="nostoHelperScope" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Nosto\Tagging\Console\Command\NostoAccountRemoveCommand">
+        <arguments>
+            <argument name="accountHelper" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+            <argument name="nostoHelperScope" xsi:type="object">Nosto\Tagging\Helper\Scope\Proxy</argument>
+            <argument name="nostoHelperCache" xsi:type="object">Nosto\Tagging\Helper\Cache\Proxy</argument>
+        </arguments>
+    </type>
     <type name="Nosto\Tagging\Logger\Logger">
         <arguments>
             <argument name="name" xsi:type="string">nosto</argument>


### PR DESCRIPTION
We want to avoid DI chain reaction and unnecessary database connection establishments when running console commands. All console constructors are invoked when running `bin/magento` command.  

## Description
Define all Nosto dependencies to be proxies that are invoked only when needed. 

## Related Issue
#440 

# Motivation and Context
This is breaking some CI builds that don't have database schema at all.  

## How Has This Been Tested?
Tested running Nosto commands locally. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
