### PR TITLE
Hotfix/3.6.1

### DIFF
--- a/Block/Stub.php
+++ b/Block/Stub.php
@@ -45,6 +45,9 @@ class Stub extends Template
         TaggingTrait::__construct as taggingConstruct; // @codingStandardsIgnoreLine
     }
 
+    /**
+     * @var NostoHelperData
+     */
     private $nostoHelperData;
 
     /**
@@ -52,6 +55,7 @@ class Stub extends Template
      * @param Template\Context $context the context.
      * @param NostoHelperAccount $nostoHelperAccount
      * @param NostoHelperScope $nostoHelperScope
+     * @param NostoHelperData $nostoHelperData
      * @param array $data optional data.
      */
     public function __construct(
@@ -76,7 +80,9 @@ class Stub extends Template
     }
 
     /**
-     * If the autoload recos is disabled or not
+     * Returns if autoloading recommendations is disabled or not.
+     * For example if price variations are enabled there's no sense
+     * of loading recos before the variation tagging is in place.
      *
      * @return boolean
      */

--- a/Block/Stub.php
+++ b/Block/Stub.php
@@ -30,6 +30,7 @@ namespace Nosto\Tagging\Block;
 use Magento\Framework\View\Element\Template;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+use Nosto\Tagging\Helper\Data as NostoHelperData;
 
 /**
  * Nosto JS stub block
@@ -44,6 +45,8 @@ class Stub extends Template
         TaggingTrait::__construct as taggingConstruct; // @codingStandardsIgnoreLine
     }
 
+    private $nostoHelperData;
+
     /**
      * Stub constructor.
      * @param Template\Context $context the context.
@@ -55,10 +58,12 @@ class Stub extends Template
         Template\Context $context,
         NostoHelperAccount $nostoHelperAccount,
         NostoHelperScope $nostoHelperScope,
+        NostoHelperData $nostoHelperData,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->taggingConstruct($nostoHelperAccount, $nostoHelperScope);
+        $this->nostoHelperData = $nostoHelperData;
     }
 
     /**
@@ -68,5 +73,17 @@ class Stub extends Template
     public function getAbstractObject()
     {
         return null;
+    }
+
+    /**
+     * If the autoload recos is disabled or not
+     *
+     * @return boolean
+     */
+    public function isRecoAutoloadDisabled()
+    {
+        return (bool) $this->nostoHelperData->isPricingVariationEnabled(
+            $this->getNostoHelperScope()->getStore(true)
+        );
     }
 }

--- a/Block/TaggingTrait.php
+++ b/Block/TaggingTrait.php
@@ -80,6 +80,14 @@ trait TaggingTrait
     }
 
     /**
+     * @return NostoHelperScope
+     */
+    public function getNostoHelperScope()
+    {
+        return $this->nostoHelperScope;
+    }
+
+    /**
      * @return AbstractObject
      */
     abstract public function getAbstractObject();

--- a/Block/TaggingTrait.php
+++ b/Block/TaggingTrait.php
@@ -88,6 +88,14 @@ trait TaggingTrait
     }
 
     /**
+     * @return NostoHelperAccount
+     */
+    public function getNostoHelperAccount()
+    {
+        return $this->nostoHelperAccount;
+    }
+
+    /**
      * @return AbstractObject
      */
     abstract public function getAbstractObject();

--- a/Block/Variation.php
+++ b/Block/Variation.php
@@ -84,12 +84,6 @@ class Variation extends Template
     public function getVariationId()
     {
         $store = $this->nostoHelperScope->getStore(true);
-        if ($this->nostoHelperData->isMultiCurrencyDisabled($store)
-            && $this->nostoHelperData->isPricingVariationEnabled($store)
-        ) {
-            return $this->nostoHelperCustomer->getGroupCode();
-        }
-
         return $store->getCurrentCurrencyCode();
     }
 
@@ -114,8 +108,9 @@ class Variation extends Template
     {
         $store = $this->nostoHelperScope->getStore(true);
 
+        // The customer price group is handled by sections
         if ($this->nostoHelperCurrency->exchangeRatesInUse($store)
-            || $this->nostoHelperData->isPricingVariationEnabled($store)
+            && !$this->nostoHelperData->isPricingVariationEnabled($store)
         ) {
             return new MarkupableString(
                 $this->getVariationId(),

--- a/Block/Variation.php
+++ b/Block/Variation.php
@@ -32,9 +32,10 @@ use Magento\Framework\View\Element\Template\Context;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Currency as NostoHelperCurrency;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
-use Nosto\Object\MarkupableString;
 use Nosto\Tagging\Helper\Data as NostoHelperData;
 use Nosto\Tagging\Helper\Customer as NostoHelperCustomer;
+use Nosto\Tagging\Helper\Variation as NostoHelperVariation;
+use Nosto\Object\MarkupableString;
 
 /**
  * Page type block used for outputting the variation identifier on the different pages.
@@ -45,18 +46,36 @@ class Variation extends Template
         TaggingTrait::__construct as taggingConstruct; // @codingStandardsIgnoreLine
     }
 
+    /**
+     * @var NostoHelperCurrency
+     */
     private $nostoHelperCurrency;
+
+    /**
+     * @var NostoHelperData
+     */
     private $nostoHelperData;
+
+    /**
+     * @var NostoHelperCustomer
+     */
     private $nostoHelperCustomer;
 
     /**
-     * Variation block constructor.
+     * @var NostoHelperVariation
+     */
+    private $nostoHelperVariation;
+
+    /**
+     * Variation constructor.
      *
      * @param Context $context
      * @param NostoHelperAccount $nostoHelperAccount
      * @param NostoHelperScope $nostoHelperScope
      * @param NostoHelperCurrency $nostoHelperCurrency
      * @param NostoHelperData $nostoHelperData
+     * @param NostoHelperCustomer $nostoHelperCustomer
+     * @param NostoHelperVariation $nostoHelperVariation
      * @param array $data
      */
     public function __construct(
@@ -66,6 +85,7 @@ class Variation extends Template
         NostoHelperCurrency $nostoHelperCurrency,
         NostoHelperData $nostoHelperData,
         NostoHelperCustomer $nostoHelperCustomer,
+        NostoHelperVariation $nostoHelperVariation,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -74,6 +94,7 @@ class Variation extends Template
         $this->nostoHelperCurrency = $nostoHelperCurrency;
         $this->nostoHelperData = $nostoHelperData;
         $this->nostoHelperCustomer = $nostoHelperCustomer;
+        $this->nostoHelperVariation = $nostoHelperVariation;
     }
 
     /**
@@ -84,6 +105,12 @@ class Variation extends Template
     public function getVariationId()
     {
         $store = $this->nostoHelperScope->getStore(true);
+        if ($this->nostoHelperData->isMultiCurrencyDisabled($store)
+            && $this->nostoHelperData->isPricingVariationEnabled($store)
+        ) {
+            return $this->nostoHelperCustomer->getGroupCode();
+        }
+
         return $store->getCurrentCurrencyCode();
     }
 
@@ -108,9 +135,16 @@ class Variation extends Template
     {
         $store = $this->nostoHelperScope->getStore(true);
 
-        // The customer price group is handled by sections
+        // We inject the active variation tag if the exchange rates are used or
+        // if the price variations are used and the active variation is the
+        // default one
         if ($this->nostoHelperCurrency->exchangeRatesInUse($store)
-            && !$this->nostoHelperData->isPricingVariationEnabled($store)
+            || ($this->nostoHelperData->isPricingVariationEnabled($store)
+                && $this->nostoHelperVariation->isDefaultVariationCode(
+                    $this->nostoHelperCustomer->getGroupCode()
+                )
+
+            )
         ) {
             return new MarkupableString(
                 $this->getVariationId(),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.6.1
+* Use sections for active variation tagging when price variations are enabled
+* Exclude base variation from variation collection
+
 ### 3.6.0
 * Add support for persistent customer reference 
 * Enrich the customer tagging to contain more fields

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -34,34 +34,44 @@
  *
  */
 
-/**
- *     ______     ___     ____  _____  ___   _________   ________ ______  _____ _________
- *    |_   _ `. .'   `.  |_   \|_   _.'   `.|  _   _  | |_   __  |_   _ `|_   _|  _   _  |
- *      | | `. /  .-.  \   |   \ | |/  .-.  |_/ | | \_|   | |_ \_| | | `. \| | |_/ | | \_|
- *      | |  | | |   | |   | |\ \| || |   | |   | |       |  _| _  | |  | || |     | |
- *     _| |_.' \  `-'  /  _| |_\   |\  `-'  /  _| |_     _| |__/ |_| |_.' _| |_   _| |_
- *    |______.' `.___.'  |_____|\____`.___.'  |_____|   |________|______.|_____| |_____|
- *
- * Nosto sends information over both the API and the broswer tagging. Values for the tagging is generated
- * via the Nosto corresponding objects. In order to customize the values in the markup below, you will need
- * to override the core parts of the extension. Failure to do so will result in broken and incorrect
- * recommendations.
- * Please see a reference guide such as https://github.com/Nosto/nosto-magento2/wiki
- *
- * @var $this Nosto\Tagging\Block\Stub
- */
-?>
-<!-- Nosto Javascript Stub -->
-<script type="text/javascript">
-    (function () {
-        var name = "nostojs";
-        window[name] = window[name] || function (cb) {
-                (window[name].q = window[name].q || []).push(cb);
-            };
-        <?php if ($this->isRecoAutoloadDisabled()): ?>
-        window[name](function(api){
-            api.setAutoLoad(false);
-        });
-    })();
-    <?php endif; ?>
-</script>
+namespace Nosto\Tagging\CustomerData;
+
+use Nosto\Tagging\Helper\Data as NostoHelperData;
+use Nosto\Tagging\Helper\Customer as NostoHelperCustomer;
+use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+
+use Magento\Customer\CustomerData\SectionSourceInterface;
+
+class ActiveVariationTagging implements SectionSourceInterface
+{
+    private $nostoHelperData;
+    private $nostoHelperCustomer;
+    private $nostoHelperScope;
+
+    public function __construct(
+        NostoHelperData $nostoHelperData,
+        NostoHelperCustomer $nostoHelperCustomer,
+        NostoHelperScope $nostoHelperScope
+    ) {
+        $this->nostoHelperData = $nostoHelperData;
+        $this->nostoHelperCustomer = $nostoHelperCustomer;
+        $this->nostoHelperScope = $nostoHelperScope;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSectionData()
+    {
+        $data = [];
+        if (
+            $this->nostoHelperData->isPricingVariationEnabled(
+                $this->nostoHelperScope->getStore(true)
+            )
+        ) {
+            $data['active_variation'] = $this->nostoHelperCustomer->getGroupCode();
+        }
+
+        return $data;
+    }
+}

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -69,6 +69,7 @@ class ActiveVariationTagging implements SectionSourceInterface
      * @param NostoHelperData $nostoHelperData
      * @param NostoHelperCustomer $nostoHelperCustomer
      * @param NostoHelperScope $nostoHelperScope
+     * @param NostoLogger $nostoHelperScope
      */
     public function __construct(
         NostoHelperData $nostoHelperData,

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -36,10 +36,11 @@
 
 namespace Nosto\Tagging\CustomerData;
 
+use Magento\Customer\CustomerData\SectionSourceInterface;
 use Nosto\Tagging\Helper\Data as NostoHelperData;
 use Nosto\Tagging\Helper\Customer as NostoHelperCustomer;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
-use Magento\Customer\CustomerData\SectionSourceInterface;
+use Nosto\Tagging\Helper\Variation as NostoHelperVariation;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 
 class ActiveVariationTagging implements SectionSourceInterface
@@ -60,6 +61,11 @@ class ActiveVariationTagging implements SectionSourceInterface
     private $nostoHelperScope;
 
     /**
+     * @var NostoHelperVariation
+     */
+    private $nostoHelperVariation;
+
+    /**
      * @var NostoLogger
      */
     private $nostoLogger;
@@ -75,11 +81,13 @@ class ActiveVariationTagging implements SectionSourceInterface
         NostoHelperData $nostoHelperData,
         NostoHelperCustomer $nostoHelperCustomer,
         NostoHelperScope $nostoHelperScope,
+        NostoHelperVariation $nostoHelperVariation,
         NostoLogger $nostoLogger
     ) {
         $this->nostoHelperData = $nostoHelperData;
         $this->nostoHelperCustomer = $nostoHelperCustomer;
         $this->nostoHelperScope = $nostoHelperScope;
+        $this->nostoHelperVariation = $nostoHelperVariation;
         $this->nostoLogger = $nostoLogger;
     }
 
@@ -89,9 +97,12 @@ class ActiveVariationTagging implements SectionSourceInterface
     public function getSectionData()
     {
         $data = [];
-        if ($this->nostoHelperData->isPricingVariationEnabled(
-            $this->nostoHelperScope->getStore(true)
-        )) {
+        $store = $this->nostoHelperScope->getStore(true);
+        if ($this->nostoHelperData->isPricingVariationEnabled($store)
+            && !$this->nostoHelperVariation->isDefaultVariationCode(
+                $this->nostoHelperCustomer->getGroupCode()
+            )
+        ) {
             try {
                 $data['active_variation'] = $this->nostoHelperCustomer->getGroupCode();
             } catch (\Exception $e) {

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -79,9 +79,8 @@ class ActiveVariationTagging implements SectionSourceInterface
     {
         $data = [];
         if ($this->nostoHelperData->isPricingVariationEnabled(
-                $this->nostoHelperScope->getStore(true)
-            )
-        ) {
+            $this->nostoHelperScope->getStore(true)
+        )) {
             $data['active_variation'] = $this->nostoHelperCustomer->getGroupCode();
         }
 

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -69,7 +69,7 @@ class ActiveVariationTagging implements SectionSourceInterface
      * @param NostoHelperData $nostoHelperData
      * @param NostoHelperCustomer $nostoHelperCustomer
      * @param NostoHelperScope $nostoHelperScope
-     * @param NostoLogger $nostoHelperScope
+     * @param NostoLogger $nostoLogger
      */
     public function __construct(
         NostoHelperData $nostoHelperData,

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -40,6 +40,7 @@ use Nosto\Tagging\Helper\Data as NostoHelperData;
 use Nosto\Tagging\Helper\Customer as NostoHelperCustomer;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Magento\Customer\CustomerData\SectionSourceInterface;
+use Nosto\Tagging\Logger\Logger as NostoLogger;
 
 class ActiveVariationTagging implements SectionSourceInterface
 {
@@ -47,14 +48,21 @@ class ActiveVariationTagging implements SectionSourceInterface
      * @var NostoHelperData
      */
     private $nostoHelperData;
+
     /**
      * @var NostoHelperCustomer
      */
     private $nostoHelperCustomer;
+
     /**
      * @var NostoHelperScope
      */
     private $nostoHelperScope;
+
+    /**
+     * @var NostoLogger
+     */
+    private $nostoLogger;
 
     /**
      * ActiveVariationTagging constructor.
@@ -65,11 +73,13 @@ class ActiveVariationTagging implements SectionSourceInterface
     public function __construct(
         NostoHelperData $nostoHelperData,
         NostoHelperCustomer $nostoHelperCustomer,
-        NostoHelperScope $nostoHelperScope
+        NostoHelperScope $nostoHelperScope,
+        NostoLogger $nostoLogger
     ) {
         $this->nostoHelperData = $nostoHelperData;
         $this->nostoHelperCustomer = $nostoHelperCustomer;
         $this->nostoHelperScope = $nostoHelperScope;
+        $this->nostoLogger = $nostoLogger;
     }
 
     /**
@@ -81,7 +91,11 @@ class ActiveVariationTagging implements SectionSourceInterface
         if ($this->nostoHelperData->isPricingVariationEnabled(
             $this->nostoHelperScope->getStore(true)
         )) {
-            $data['active_variation'] = $this->nostoHelperCustomer->getGroupCode();
+            try {
+                $data['active_variation'] = $this->nostoHelperCustomer->getGroupCode();
+            } catch (\Exception $e) {
+                $this->nostoLogger->exception($e);
+            }
         }
 
         return $data;

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -78,8 +78,7 @@ class ActiveVariationTagging implements SectionSourceInterface
     public function getSectionData()
     {
         $data = [];
-        if (
-            $this->nostoHelperData->isPricingVariationEnabled(
+        if ($this->nostoHelperData->isPricingVariationEnabled(
                 $this->nostoHelperScope->getStore(true)
             )
         ) {

--- a/CustomerData/ActiveVariationTagging.php
+++ b/CustomerData/ActiveVariationTagging.php
@@ -39,15 +39,29 @@ namespace Nosto\Tagging\CustomerData;
 use Nosto\Tagging\Helper\Data as NostoHelperData;
 use Nosto\Tagging\Helper\Customer as NostoHelperCustomer;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
-
 use Magento\Customer\CustomerData\SectionSourceInterface;
 
 class ActiveVariationTagging implements SectionSourceInterface
 {
+    /**
+     * @var NostoHelperData
+     */
     private $nostoHelperData;
+    /**
+     * @var NostoHelperCustomer
+     */
     private $nostoHelperCustomer;
+    /**
+     * @var NostoHelperScope
+     */
     private $nostoHelperScope;
 
+    /**
+     * ActiveVariationTagging constructor.
+     * @param NostoHelperData $nostoHelperData
+     * @param NostoHelperCustomer $nostoHelperCustomer
+     * @param NostoHelperScope $nostoHelperScope
+     */
     public function __construct(
         NostoHelperData $nostoHelperData,
         NostoHelperCustomer $nostoHelperCustomer,

--- a/Helper/Variation.php
+++ b/Helper/Variation.php
@@ -44,6 +44,7 @@ use Magento\Store\Model\Store;
 use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Customer\Model\Customer;
 
 /**
  * Variation helper
@@ -96,5 +97,24 @@ class Variation extends AbstractHelper
     public function getDefaultVariationCode()
     {
         return $this->getDefaultGroupVariation() ? $this->getDefaultGroupVariation()->getCode() : null;
+    }
+
+    /**
+     * Checks if the code is the default variation
+     *
+     * @param string $code
+     * @return bool
+     */
+    public function isDefaultVariationCode($code)
+    {
+        try {
+            if ($code === $this->getDefaultVariationCode()) {
+                return true;
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return false;
     }
 }

--- a/Model/Product/Variation/Collection.php
+++ b/Model/Product/Variation/Collection.php
@@ -81,6 +81,11 @@ class Collection
         $collection = new VariationCollection();
         $groups = $this->customerGroupManager->getLoggedInGroups();
         foreach ($groups as $group) {
+            // For some (broken?) Magento setups the default group / default
+            // variation is also part of the customer groups
+            if ($group->getCode() === $nostoProduct->getVariationId()) {
+                continue;
+            }
             /** @var \Magento\Customer\Model\Data\Group $group */
             $collection->append(
                 $this->variationBuilder->build(

--- a/Model/Product/Variation/Collection.php
+++ b/Model/Product/Variation/Collection.php
@@ -83,7 +83,7 @@ class Collection
         foreach ($groups as $group) {
             // For some (broken?) Magento setups the default group / default
             // variation is also part of the customer groups
-            if ($group->getCode() === $nostoProduct->getVariationId()) {
+            if ($group->getCode() === (string)$nostoProduct->getVariationId()) {
                 continue;
             }
             /** @var \Magento\Customer\Model\Data\Group $group */

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -42,6 +42,7 @@
             <argument name="sectionSourceMap" xsi:type="array">
                 <item name="customer-tagging" xsi:type="string">Nosto\Tagging\CustomerData\CustomerTagging</item>
                 <item name="cart-tagging" xsi:type="string">Nosto\Tagging\CustomerData\CartTagging</item>
+                <item name="active-variation-tagging" xsi:type="string">Nosto\Tagging\CustomerData\ActiveVariationTagging</item>
             </argument>
         </arguments>
     </type>

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -42,6 +42,7 @@
     <action name="customer/account/createPost"/>
     <action name="customer/ajax/login">
         <section name="customer-tagging"/>
+        <section name="active-variation-tagging"/>
     </action>
     <action name="checkout/cart/add">
         <section name="cart-tagging"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.6.0"/>
+    <module name="Nosto_Tagging" setup_version="3.6.1"/>
 </config>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -47,7 +47,7 @@
                    template="Nosto_Tagging::embed.phtml"/>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Nosto\Tagging\Block\Variation" name="nosto.variation" before="-"/>
+            <block class="Nosto\Tagging\Block\Variation" name="nosto.currency.variation" before="-"/>
             <block class="Nosto\Tagging\Block\Addtocart" name="nosto.page.type.addtocart" after="-"
                    template="Nosto_Tagging::addtocart.phtml">
             </block>
@@ -70,6 +70,18 @@
                         <item name="components" xsi:type="array">
                             <item name="customerTagging" xsi:type="array">
                                 <item name="component" xsi:type="string">Nosto_Tagging/js/view/customer-tagging</item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
+            <block class="Nosto\Tagging\Block\Knockout" name="nosto.price.variation" after="nosto.cart"
+                   template="Nosto_Tagging::variation.phtml">
+                <arguments>
+                    <argument name="jsLayout" xsi:type="array">
+                        <item name="components" xsi:type="array">
+                            <item name="variationTagging" xsi:type="array">
+                                <item name="component" xsi:type="string">Nosto_Tagging/js/view/variation-tagging</item>
                             </item>
                         </item>
                     </argument>

--- a/view/frontend/templates/jsstub.phtml
+++ b/view/frontend/templates/jsstub.phtml
@@ -48,7 +48,7 @@
  * recommendations.
  * Please see a reference guide such as https://github.com/Nosto/nosto-magento2/wiki
  *
- * @var $this Nosto\Tagging\Block\Stub
+ * @var Nosto\Tagging\Block\Stub $this
  */
 ?>
 <!-- Nosto Javascript Stub -->

--- a/view/frontend/templates/variation.phtml
+++ b/view/frontend/templates/variation.phtml
@@ -62,7 +62,7 @@
      data-role="nosto-variation-tagging"
 >
     <!-- ko if: variationTagging().active_variation -->
-    <span class="nosto_variation" data-bind="text: variationTagging().active_variation, afterRender: reloadRecommendations"></span>
+    <span class="nosto_variation_dynamic" data-bind="text: variationTagging().active_variation, afterRender: reloadRecommendations"></span>
     <!-- /ko -->
 </div>
 <script type="text/x-magento-init">

--- a/view/frontend/templates/variation.phtml
+++ b/view/frontend/templates/variation.phtml
@@ -47,21 +47,24 @@
  * to override the core parts of the extension. Failure to do so will result in broken and incorrect
  * recommendations.
  * Please see a reference guide such as https://github.com/Nosto/nosto-magento2/wiki
+ */
+
+/**
+ * Template for customer tagging. The actual data is populated via
+ * Magento's KnockoutJS logic.
  *
- * @var $this Nosto\Tagging\Block\Stub
+ * @see \Nosto\Tagging\CustomerData\ActiveVariationTagging
  */
 ?>
-<!-- Nosto Javascript Stub -->
-<script type="text/javascript">
-    (function () {
-        var name = "nostojs";
-        window[name] = window[name] || function (cb) {
-                (window[name].q = window[name].q || []).push(cb);
-            };
-        <?php if ($this->isRecoAutoloadDisabled()): ?>
-        window[name](function(api){
-            api.setAutoLoad(false);
-        });
-    })();
-    <?php endif; ?>
+<!-- Nosto Variation Tagging -->
+<div id="nosto_variation_tagging" style="display:none"
+     data-bind="scope: 'variationTagging'"
+     data-role="nosto-variation-tagging"
+>
+    <!-- ko if: variationTagging().active_variation -->
+    <span class="nosto_variation" data-bind="text: variationTagging().active_variation, afterRender: reloadRecommendations"></span>
+    <!-- /ko -->
+</div>
+<script type="text/x-magento-init">
+{"[data-role=nosto-variation-tagging]": {"Magento_Ui/js/core/app": <?php /* @escapeNotVerified */ echo $block->getJsLayout();?>}}
 </script>

--- a/view/frontend/web/js/view/variation-tagging.js
+++ b/view/frontend/web/js/view/variation-tagging.js
@@ -48,7 +48,9 @@ define([
             this.variationTagging = customerData.get('active-variation-tagging');
         },
         reloadRecommendations: function () {
-            //noinspection JSUnresolvedVariable
+            // Remove the static variation if it exists - it should not but as a safeguard we rename the class
+            $('.nosto_variation').removeClass('nosto_variation').addClass('nosto_variation_static');
+            $('.nosto_variation_dynamic').addClass('nosto_variation');
             if (typeof nostojs === 'function') {
                 nostojs(function (api) {
                     api.loadRecommendations();

--- a/view/frontend/web/js/view/variation-tagging.js
+++ b/view/frontend/web/js/view/variation-tagging.js
@@ -1,5 +1,4 @@
-<?php
-/**
+/*
  * Copyright (c) 2019, Nosto Solutions Ltd
  * All rights reserved.
  *
@@ -34,34 +33,27 @@
  *
  */
 
-/**
- *     ______     ___     ____  _____  ___   _________   ________ ______  _____ _________
- *    |_   _ `. .'   `.  |_   \|_   _.'   `.|  _   _  | |_   __  |_   _ `|_   _|  _   _  |
- *      | | `. /  .-.  \   |   \ | |/  .-.  |_/ | | \_|   | |_ \_| | | `. \| | |_/ | | \_|
- *      | |  | | |   | |   | |\ \| || |   | |   | |       |  _| _  | |  | || |     | |
- *     _| |_.' \  `-'  /  _| |_\   |\  `-'  /  _| |_     _| |__/ |_| |_.' _| |_   _| |_
- *    |______.' `.___.'  |_____|\____`.___.'  |_____|   |________|______.|_____| |_____|
- *
- * Nosto sends information over both the API and the broswer tagging. Values for the tagging is generated
- * via the Nosto corresponding objects. In order to customize the values in the markup below, you will need
- * to override the core parts of the extension. Failure to do so will result in broken and incorrect
- * recommendations.
- * Please see a reference guide such as https://github.com/Nosto/nosto-magento2/wiki
- *
- * @var $this Nosto\Tagging\Block\Stub
- */
-?>
-<!-- Nosto Javascript Stub -->
-<script type="text/javascript">
-    (function () {
-        var name = "nostojs";
-        window[name] = window[name] || function (cb) {
-                (window[name].q = window[name].q || []).push(cb);
-            };
-        <?php if ($this->isRecoAutoloadDisabled()): ?>
-        window[name](function(api){
-            api.setAutoLoad(false);
-        });
-    })();
-    <?php endif; ?>
-</script>
+define([
+    'uiComponent',
+    'Magento_Customer/js/customer-data',
+    'nostojs',
+    'jquery'
+], function (Component, customerData, nostojs, $) {
+    'use strict';
+
+    return Component.extend({
+        initialize: function () {
+            this._super();
+            //noinspection JSUnusedGlobalSymbols
+            this.variationTagging = customerData.get('active-variation-tagging');
+        },
+        reloadRecommendations: function (el) {
+            //noinspection JSUnresolvedVariable
+            if (typeof nostojs === 'function') {
+                nostojs(function (api) {
+                    api.loadRecommendations();
+                });
+            }
+        }
+    });
+});

--- a/view/frontend/web/js/view/variation-tagging.js
+++ b/view/frontend/web/js/view/variation-tagging.js
@@ -47,7 +47,7 @@ define([
             //noinspection JSUnusedGlobalSymbols
             this.variationTagging = customerData.get('active-variation-tagging');
         },
-        reloadRecommendations: function (el) {
+        reloadRecommendations: function () {
             //noinspection JSUnresolvedVariable
             if (typeof nostojs === 'function') {
                 nostojs(function (api) {


### PR DESCRIPTION
Active Nosto variation doesn't change according to the customer group when price variations are used and full page cache is enabled.   

Also, price variations collections should not contain the base price variation.

## Description
When price variations are in use the active variation must be set using sections:  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cache/page-caching/private-content.html.

A check for base variation id is added before adding variation into the price variation collection.  

## How it works
If the price variations are enabled but user is not logged in or has the default variation group (NOT LOGGED IN) the active variation will be injected statically via normal block ( https://github.com/Nosto/nosto-magento2/pull/450/files#diff-51a52ff430049cbca0bc134a740d7605R142). This is due to the fact the sections are loaded & populated only when user logs in or logs out. When user logs in the static variation is not injected but the sections handle setting the active variation.  

## Related Issue
#448 
#437 

## Motivation and Context
The price variation was not updated according to the logged in user's customer group. 

## How Has This Been Tested?
* with exchange rates enabled and disabled
* with price variations enabled and disabled

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
