### PR TITLE
Category Personalization - Ignore product ids if they are not numeric

### DIFF
--- a/Model/Service/Recommendation/Category.php
+++ b/Model/Service/Recommendation/Category.php
@@ -77,7 +77,7 @@ class Category
         if (!$featureAccess->canUseGraphql()) {
             return $productIds;
         }
-        if ((string)$type === NostoHelperSorting::NOSTO_PERSONALIZED_KEY) {
+        if ($type === NostoHelperSorting::NOSTO_PERSONALIZED_KEY) {
             $recoOperation = new CategoryBrowsingHistory($nostoAccount, $nostoCustomerId);
         } else {
             $recoOperation = new CategoryTopList($nostoAccount, $nostoCustomerId);

--- a/Model/Service/Recommendation/Category.php
+++ b/Model/Service/Recommendation/Category.php
@@ -86,7 +86,7 @@ class Category
         try {
             $result = $recoOperation->execute();
             foreach ($result as $item) {
-                if ($item->getProductId() && is_int($item->getProductId())) {
+                if ($item->getProductId() && is_numeric($item->getProductId())) {
                     $productIds[] = $item->getProductId();
                 }
             }

--- a/Model/Service/Recommendation/Category.php
+++ b/Model/Service/Recommendation/Category.php
@@ -77,27 +77,22 @@ class Category
         if (!$featureAccess->canUseGraphql()) {
             return $productIds;
         }
-
-        switch ($type) {
-            case NostoHelperSorting::NOSTO_PERSONALIZED_KEY:
-                $recoOperation = new CategoryBrowsingHistory($nostoAccount, $nostoCustomerId);
-                break;
-            default:
-                $recoOperation = new CategoryTopList($nostoAccount, $nostoCustomerId);
-                break;
+        if ((string)$type === NostoHelperSorting::NOSTO_PERSONALIZED_KEY) {
+            $recoOperation = new CategoryBrowsingHistory($nostoAccount, $nostoCustomerId);
+        } else {
+            $recoOperation = new CategoryTopList($nostoAccount, $nostoCustomerId);
         }
         $recoOperation->setCategory($category);
         try {
             $result = $recoOperation->execute();
             foreach ($result as $item) {
-                if ($item->getProductId()) {
+                if ($item->getProductId() && is_int($item->getProductId())) {
                     $productIds[] = $item->getProductId();
                 }
             }
         } catch (\Exception $e) {
             $this->logger->exception($e);
         }
-
         return $productIds;
     }
 }


### PR DESCRIPTION
## Description
If Category Personalization GraphQL calls return products with non-numeric id's, they are no longer used for sorting.

## Related Issue
Closes #438 

## Motivation and Context
The sorting could crash if non-numeric product ids were used.

## How Has This Been Tested?
Tested with preview mode enabled and mock products id's such as `nostomp1`.

## Documentation:
N/A

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
