### PR TITLE
Bump SDK to 3.14.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "nosto/php-sdk": "3.13.0",
+    "nosto/php-sdk": "3.14.1",
     "php": ">=7.0.0"
   },
   "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -1,30 +1,29 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "772d40e0afe16421f2ba0f761637fa29",
-    "content-hash": "3bf25e9c7c3c7b3b80b988dbf705dbea",
+    "content-hash": "8c416e4a28f8d9e9281f7b832d0bb6a5",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "3.13.0",
+            "version": "3.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "980fdeeab0583cae842cffc04552842edb33e046"
+                "reference": "187238e6d2545b77f496647c6b116ce5ebaf55e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/980fdeeab0583cae842cffc04552842edb33e046",
-                "reference": "980fdeeab0583cae842cffc04552842edb33e046",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/187238e6d2545b77f496647c6b116ce5ebaf55e5",
+                "reference": "187238e6d2545b77f496647c6b116ce5ebaf55e5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
                 "phpseclib/phpseclib": "2.0.*",
-                "vlucas/phpdotenv": ">=2.4.0 <=2.6"
+                "vlucas/phpdotenv": ">=2.4.0 <=3.0"
             },
             "require-dev": {
                 "codeception/base": "2.2.9",
@@ -52,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-04-08 13:02:49"
+            "time": "2019-05-21T08:15:38+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -144,7 +143,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2019-04-12 02:56:17"
+            "time": "2019-04-12T02:56:17+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -202,7 +201,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06 07:57:58"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -253,7 +252,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2019-01-28 20:57:27"
+            "time": "2019-01-28T20:57:27+00:00"
         }
     ],
     "packages-dev": [
@@ -295,7 +294,7 @@
             ],
             "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
             "homepage": "https://github.com/colinmollenhour/credis",
-            "time": "2019-03-05 16:29:14"
+            "time": "2019-03-05T16:29:14+00:00"
         },
         {
             "name": "colinmollenhour/php-redis-session-abstract",
@@ -332,7 +331,7 @@
             ],
             "description": "A Redis-based session handler with optimistic locking",
             "homepage": "https://github.com/colinmollenhour/php-redis-session-abstract",
-            "time": "2017-03-22 16:13:03"
+            "time": "2017-03-22T16:13:03+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -388,7 +387,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2019-03-26 10:08:35"
+            "time": "2019-03-26T10:08:35+00:00"
         },
         {
             "name": "composer/composer",
@@ -468,7 +467,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-04-10 11:11:57"
+            "time": "2019-04-10T11:11:57+00:00"
         },
         {
             "name": "composer/semver",
@@ -529,7 +528,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2019-04-14 09:35:30"
+            "time": "2019-04-14T09:35:30+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -589,7 +588,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2019-04-14 09:38:00"
+            "time": "2019-04-14T09:38:00+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -633,7 +632,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2019-01-28 20:25:53"
+            "time": "2019-01-28T20:25:53+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -664,7 +663,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14 19:40:03"
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -730,7 +729,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2019-01-14 23:55:14"
+            "time": "2019-01-14T23:55:14+00:00"
         },
         {
             "name": "magento-ecg/coding-standard",
@@ -763,7 +762,7 @@
             ],
             "description": "A set of PHP_CodeSniffer rules and sniffs.",
             "homepage": "https://github.com/magento-ecg/coding-standard",
-            "time": "2017-05-18 19:12:29"
+            "time": "2017-05-18T19:12:29+00:00"
         },
         {
             "name": "magento/framework",
@@ -771,7 +770,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/framework/magento-framework-101.0.8.0.zip",
-                "reference": null,
                 "shasum": "37c0217eecbdc04cf50896b58f123374688a2573"
             },
             "require": {
@@ -828,7 +826,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/marketplace-eqp/magento-marketplace-eqp-1.0.5.0.zip",
-                "reference": null,
                 "shasum": "409b87f408262b7b037e830e1f4c94563548679e"
             },
             "require": {
@@ -852,7 +849,8 @@
                 "url": "https://github.com/magento/marketplace-tools",
                 "reference": "origin/master"
             },
-            "type": "library"
+            "type": "library",
+            "time": "2017-04-06T01:16:20+00:00"
         },
         {
             "name": "magento/module-authorization",
@@ -860,7 +858,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-authorization/magento-module-authorization-100.2.3.0.zip",
-                "reference": null,
                 "shasum": "3fe567523e5c300b13689671bf016bfcd472fb3b"
             },
             "require": {
@@ -889,7 +886,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-backend/magento-module-backend-100.2.8.0.zip",
-                "reference": null,
                 "shasum": "1c5ee8aa6633b8e42a181e75dce4a28ef06bf6c1"
             },
             "require": {
@@ -935,7 +931,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-backup/magento-module-backup-100.2.7.0.zip",
-                "reference": null,
                 "shasum": "c4849e91322288f4313dfe7e9e5dcb134cb0b865"
             },
             "require": {
@@ -966,7 +961,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-bundle/magento-module-bundle-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "21414ea21169b9144a51acc41528c25c33715fe9"
             },
             "require": {
@@ -1013,7 +1007,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-captcha/magento-module-captcha-100.2.5.0.zip",
-                "reference": null,
                 "shasum": "5496cc579816c301ea80b56e07cb67f7192c4e0f"
             },
             "require": {
@@ -1048,7 +1041,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-catalog/magento-module-catalog-102.0.8.0.zip",
-                "reference": null,
                 "shasum": "3cb9e6a01808e7d152e1063df6860a46f26ed8d7"
             },
             "require": {
@@ -1104,7 +1096,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-catalog-import-export/magento-module-catalog-import-export-100.2.7.0.zip",
-                "reference": null,
                 "shasum": "a2d0755490bd1c1fc903ad730c40ce73fd2dd362"
             },
             "require": {
@@ -1142,7 +1133,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-catalog-inventory/magento-module-catalog-inventory-100.2.7.0.zip",
-                "reference": null,
                 "shasum": "07b658ea61bd9ccaa74ea370734c6d48ec5f02d8"
             },
             "require": {
@@ -1178,7 +1168,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-catalog-rule/magento-module-catalog-rule-101.0.7.0.zip",
-                "reference": null,
                 "shasum": "6c1ef344193a55be2461e9215af5fac0233ce20c"
             },
             "require": {
@@ -1217,7 +1206,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-catalog-search/magento-module-catalog-search-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "c77fb9bc2a9b5aba5986fe79ff803895cda0d9ca"
             },
             "require": {
@@ -1254,7 +1242,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-catalog-url-rewrite/magento-module-catalog-url-rewrite-100.2.7.0.zip",
-                "reference": null,
                 "shasum": "3e61cbbdcf66c6316e21239975623a4ed7073292"
             },
             "require": {
@@ -1293,7 +1280,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-checkout/magento-module-checkout-100.2.8.0.zip",
-                "reference": null,
                 "shasum": "a8066c62fb711b273c7235ed314610bc236f36f0"
             },
             "require": {
@@ -1341,7 +1327,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-cms/magento-module-cms-102.0.8.0.zip",
-                "reference": null,
                 "shasum": "59c95a63f63572a3d6b31fc0daf8d8098834e838"
             },
             "require": {
@@ -1381,7 +1366,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-cms-url-rewrite/magento-module-cms-url-rewrite-100.2.3.0.zip",
-                "reference": null,
                 "shasum": "cac37d819610a7ef4da9e595a0a6fef29db19c4d"
             },
             "require": {
@@ -1412,7 +1396,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-config/magento-module-config-101.0.8.0.zip",
-                "reference": null,
                 "shasum": "3bd01060ad5ce082d5de94017e6c66922e41fa44"
             },
             "require": {
@@ -1447,7 +1430,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-configurable-product/magento-module-configurable-product-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "adee8afa5fdb60a8fa4145d5501a594a901d29f2"
             },
             "require": {
@@ -1493,7 +1475,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-contact/magento-module-contact-100.2.5.0.zip",
-                "reference": null,
                 "shasum": "fcb8badcb2781b9d0981780635d874ed5708d3ad"
             },
             "require": {
@@ -1525,7 +1506,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-cron/magento-module-cron-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "2785cbc85f5f0503889973b8544d96ed97fb9d6c"
             },
             "require": {
@@ -1557,7 +1537,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-customer/magento-module-customer-101.0.8.0.zip",
-                "reference": null,
                 "shasum": "2bfe74bea4c1c54bed0341c876680c051c5e84bb"
             },
             "require": {
@@ -1608,7 +1587,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-deploy/magento-module-deploy-100.2.7.0.zip",
-                "reference": null,
                 "shasum": "381b488b2a1a4d253f5bcacc8f5a60630effdf8d"
             },
             "require": {
@@ -1641,7 +1619,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-developer/magento-module-developer-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "c7f8b5660ba9461ac4115547ffce1572ecc52c1d"
             },
             "require": {
@@ -1671,7 +1648,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-directory/magento-module-directory-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "fc89c9f51beaf1a0b9f80e40a5d022a5b9b3580c"
             },
             "require": {
@@ -1703,7 +1679,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-downloadable/magento-module-downloadable-100.2.7.0.zip",
-                "reference": null,
                 "shasum": "20bc96609ede98ef7687c3923ed0526c31449caa"
             },
             "require": {
@@ -1750,7 +1725,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-eav/magento-module-eav-101.0.7.0.zip",
-                "reference": null,
                 "shasum": "f8ad48fac35216672f76ed468b0b2a28c2cbbb0c"
             },
             "require": {
@@ -1783,7 +1757,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-email/magento-module-email-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "181894c4f91b41b1a8681e9da2433e121d42eb24"
             },
             "require": {
@@ -1820,7 +1793,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-gift-message/magento-module-gift-message-100.2.4.0.zip",
-                "reference": null,
                 "shasum": "ec661b42d432f117b466089a8f815b3dea1de63f"
             },
             "require": {
@@ -1859,7 +1831,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-grouped-product/magento-module-grouped-product-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "7588fe1e8cf62481f3389ad026cc71c3d303498a"
             },
             "require": {
@@ -1902,7 +1873,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-import-export/magento-module-import-export-100.2.8.0.zip",
-                "reference": null,
                 "shasum": "3d4f25a05f74fb2825cb1886e0836fad353f96df"
             },
             "require": {
@@ -1936,7 +1906,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-indexer/magento-module-indexer-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "8c97f72738c731530a7f00d2354da587af3f060c"
             },
             "require": {
@@ -1965,7 +1934,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-integration/magento-module-integration-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "9b281e54d7cf8803c5c9dcde9d8c62ce6ead4178"
             },
             "require": {
@@ -1999,7 +1967,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-media-storage/magento-module-media-storage-100.2.3.0.zip",
-                "reference": null,
                 "shasum": "229db48c0bc8ea4bfa49612779809f9af46f352b"
             },
             "require": {
@@ -2030,7 +1997,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-msrp/magento-module-msrp-100.2.4.0.zip",
-                "reference": null,
                 "shasum": "a8a705ac46fc2112840b582d7f998d3fd1f6b77b"
             },
             "require": {
@@ -2068,7 +2034,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-newsletter/magento-module-newsletter-100.2.7.0.zip",
-                "reference": null,
                 "shasum": "1e05337ecf02731604b068c464697dc7dcb27794"
             },
             "require": {
@@ -2104,7 +2069,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-page-cache/magento-module-page-cache-100.2.5.0.zip",
-                "reference": null,
                 "shasum": "20d25a93d007c2a0bd557392ac298ba20b9c7896"
             },
             "require": {
@@ -2135,7 +2099,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-payment/magento-module-payment-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "70f1544ea89132090910f655a762fc85e48d65e2"
             },
             "require": {
@@ -2169,7 +2132,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-product-alert/magento-module-product-alert-100.2.4.0.zip",
-                "reference": null,
                 "shasum": "07a71e3e7e4441cef92941a52315149f7c704022"
             },
             "require": {
@@ -2204,7 +2166,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-quote/magento-module-quote-101.0.0.0.zip",
-                "reference": null,
                 "shasum": "a201d8f2093d9e72e3a705c6d5f923add4a0fcc9"
             },
             "require": {
@@ -2249,7 +2210,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-reports/magento-module-reports-100.2.8.0.zip",
-                "reference": null,
                 "shasum": "894b564dd5fabf098d9f149013f85391d6dc4a2b"
             },
             "require": {
@@ -2293,7 +2253,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-require-js/magento-module-require-js-100.2.4.0.zip",
-                "reference": null,
                 "shasum": "e07b9da4050a394f389876803e34bce3d312298e"
             },
             "require": {
@@ -2321,7 +2280,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-review/magento-module-review-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "0f98915d8a22ac27c317786c86881eb6fda88c44"
             },
             "require": {
@@ -2361,7 +2319,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-rss/magento-module-rss-100.2.3.0.zip",
-                "reference": null,
                 "shasum": "d9c9c1157e5d6f000ad1ad868c7df95c57c8d4d5"
             },
             "require": {
@@ -2392,7 +2349,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-rule/magento-module-rule-100.2.5.0.zip",
-                "reference": null,
                 "shasum": "9fbea9a0a01aa57f45e7399ad05ea3adf7cb855f"
             },
             "require": {
@@ -2425,7 +2381,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-sales/magento-module-sales-101.0.0.0.zip",
-                "reference": null,
                 "shasum": "81b0b43efc40e5bc74ecb5acb30d5ae207254c40"
             },
             "require": {
@@ -2479,7 +2434,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-sales-inventory/magento-module-sales-inventory-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "8837c4d181b9c4527c3b136de2bda5b654dc02ed"
             },
             "require": {
@@ -2511,7 +2465,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-sales-rule/magento-module-sales-rule-101.0.0.0.zip",
-                "reference": null,
                 "shasum": "712c75ed0abdffad2c470af13b9e68d7eb41dcc1"
             },
             "require": {
@@ -2558,7 +2511,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-sales-sequence/magento-module-sales-sequence-100.2.3.0.zip",
-                "reference": null,
                 "shasum": "d4ea104bb6b7f15ecbec941e36b9a99cc415db0b"
             },
             "require": {
@@ -2586,7 +2538,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-search/magento-module-search-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "34d5edf9aff635aa8ccac1033fd16dc59899e008"
             },
             "require": {
@@ -2619,7 +2570,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-security/magento-module-security-100.2.5.0.zip",
-                "reference": null,
                 "shasum": "dfe552374b9ee89dfc711c0fe5f6c1e7bdefc0c1"
             },
             "require": {
@@ -2652,7 +2602,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-shipping/magento-module-shipping-100.2.8.0.zip",
-                "reference": null,
                 "shasum": "af92426835f22971a75fce7a45f393f71e26bf26"
             },
             "require": {
@@ -2699,7 +2648,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-store/magento-module-store-100.2.0.0.zip",
-                "reference": null,
                 "shasum": "b55228c9e84e76b9005a5e16c7d3ba8b9100cf1d"
             },
             "require": {
@@ -2735,7 +2683,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-tax/magento-module-tax-100.2.8.0.zip",
-                "reference": null,
                 "shasum": "85ef466ef5baf9270cae6d540e9beb1070bfb618"
             },
             "require": {
@@ -2779,7 +2726,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-theme/magento-module-theme-100.2.8.0.zip",
-                "reference": null,
                 "shasum": "792c3b96a2e3ff4d662b40b250a65cf3a09ca935"
             },
             "require": {
@@ -2823,7 +2769,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-translation/magento-module-translation-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "6231f5802c5586508ea7fc3818c866e2036a3b47"
             },
             "require": {
@@ -2857,7 +2802,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-ui/magento-module-ui-101.0.8.0.zip",
-                "reference": null,
                 "shasum": "b93dceeba009bacac0ce62166e9c5f49c22b5fa4"
             },
             "require": {
@@ -2892,7 +2836,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-url-rewrite/magento-module-url-rewrite-101.0.7.0.zip",
-                "reference": null,
                 "shasum": "0298e56e003b20f7ca40d4f704400f5f5d4738d0"
             },
             "require": {
@@ -2926,7 +2869,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-user/magento-module-user-101.0.6.0.zip",
-                "reference": null,
                 "shasum": "805c0b6755c34e74972e62ffa0f9bb9d08137003"
             },
             "require": {
@@ -2960,7 +2902,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-variable/magento-module-variable-100.2.6.0.zip",
-                "reference": null,
                 "shasum": "37c692d50b586f1e8b74d5a07ab34522aa9bf5cb"
             },
             "require": {
@@ -2991,7 +2932,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-widget/magento-module-widget-101.0.6.0.zip",
-                "reference": null,
                 "shasum": "3debbad83c67030c73efad6d2abb652f88d4bfd9"
             },
             "require": {
@@ -3029,7 +2969,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/module-wishlist/magento-module-wishlist-101.0.6.0.zip",
-                "reference": null,
                 "shasum": "2f95082276b3cfb91dae372643215c3fcd1a9b1d"
             },
             "require": {
@@ -3114,7 +3053,7 @@
                 "ZF1",
                 "framework"
             ],
-            "time": "2017-06-21 14:56:23"
+            "time": "2017-06-21T14:56:23+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3192,7 +3131,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2018-12-26 14:24:03"
+            "time": "2018-12-26T14:24:03+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3243,7 +3182,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-02-28 20:30:58"
+            "time": "2018-02-28T20:30:58+00:00"
         },
         {
             "name": "oyejorge/less.php",
@@ -3302,7 +3241,7 @@
                 "php",
                 "stylesheet"
             ],
-            "time": "2014-03-04 18:49:54"
+            "time": "2014-03-04T18:49:54+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -3342,7 +3281,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-12-13 13:21:38"
+            "time": "2017-12-13T13:21:38+00:00"
         },
         {
             "name": "phan/phan",
@@ -3399,7 +3338,7 @@
                 "php",
                 "static"
             ],
-            "time": "2017-09-24 20:02:32"
+            "time": "2017-09-24T20:02:32+00:00"
         },
         {
             "name": "phing/phing",
@@ -3492,7 +3431,7 @@
                 "task",
                 "tool"
             ],
-            "time": "2018-01-25 13:18:09"
+            "time": "2018-01-25T13:18:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3546,7 +3485,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3591,7 +3530,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-01-28 12:45:51"
+            "time": "2016-01-28T12:45:51+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3638,7 +3577,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-03-28 10:02:29"
+            "time": "2016-03-28T10:02:29+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -3704,7 +3643,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2017-01-20 14:41:10"
+            "time": "2017-01-20T14:41:10+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -3753,7 +3692,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-20 14:16:29"
+            "time": "2019-02-20T14:16:29+00:00"
         },
         {
             "name": "psr/container",
@@ -3802,7 +3741,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2018-12-29 15:36:03"
+            "time": "2018-12-29T15:36:03+00:00"
         },
         {
             "name": "psr/http-message",
@@ -3852,7 +3791,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -3899,7 +3838,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-21 13:42:00"
+            "time": "2018-11-21T13:42:00+00:00"
         },
         {
             "name": "sebastian/finder-facade",
@@ -3938,7 +3877,7 @@
             ],
             "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
             "homepage": "https://github.com/sebastianbergmann/finder-facade",
-            "time": "2017-11-18 17:31:49"
+            "time": "2017-11-18T17:31:49+00:00"
         },
         {
             "name": "sebastian/phpcpd",
@@ -3989,7 +3928,7 @@
             ],
             "description": "Copy/Paste Detector (CPD) for PHP code.",
             "homepage": "https://github.com/sebastianbergmann/phpcpd",
-            "time": "2018-09-17 17:17:27"
+            "time": "2018-09-17T17:17:27+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4032,7 +3971,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -4081,7 +4020,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2018-01-24 12:46:19"
+            "time": "2018-01-24T12:46:19+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -4125,7 +4064,7 @@
             "keywords": [
                 "phra"
             ],
-            "time": "2015-10-13 18:44:15"
+            "time": "2015-10-13T18:44:15+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4203,7 +4142,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-07-13 23:29:13"
+            "time": "2016-07-13T23:29:13+00:00"
         },
         {
             "name": "symfony/config",
@@ -4266,7 +4205,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-09 10:34:11"
+            "time": "2019-04-09T10:34:11+00:00"
         },
         {
             "name": "symfony/console",
@@ -4327,7 +4266,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-20 15:55:20"
+            "time": "2018-11-20T15:55:20+00:00"
         },
         {
             "name": "symfony/debug",
@@ -4384,7 +4323,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:22:48"
+            "time": "2016-07-30T07:22:48+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -4454,11 +4393,11 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29 09:02:23"
+            "time": "2018-01-29T09:02:23+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "dev-master",
+            "version": "4.3.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -4504,11 +4443,11 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-27 09:50:42"
+            "time": "2019-03-27T09:50:42+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "dev-master",
+            "version": "4.3.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -4553,7 +4492,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-06 14:04:46"
+            "time": "2019-04-06T14:04:46+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -4612,7 +4551,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06 07:57:58"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/process",
@@ -4661,7 +4600,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11 11:18:13"
+            "time": "2018-11-11T11:18:13+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -4716,7 +4655,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-20 15:04:53"
+            "time": "2018-01-20T15:04:53+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -4762,7 +4701,7 @@
                 "javascript",
                 "minifier"
             ],
-            "time": "2018-09-16 00:02:51"
+            "time": "2018-09-16T00:02:51+00:00"
         },
         {
             "name": "theseer/fdomdocument",
@@ -4802,7 +4741,7 @@
             ],
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
-            "time": "2017-06-30 11:53:12"
+            "time": "2017-06-30T11:53:12+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4853,7 +4792,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25 11:19:39"
+            "time": "2018-12-25T11:19:39+00:00"
         },
         {
             "name": "zendframework/zend-captcha",
@@ -4911,7 +4850,7 @@
                 "captcha",
                 "zf"
             ],
-            "time": "2018-04-24 17:25:27"
+            "time": "2018-04-24T17:25:27+00:00"
         },
         {
             "name": "zendframework/zend-code",
@@ -4964,7 +4903,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-10-24 13:23:32"
+            "time": "2016-10-24T13:23:32+00:00"
         },
         {
             "name": "zendframework/zend-console",
@@ -5017,7 +4956,7 @@
                 "console",
                 "zf"
             ],
-            "time": "2018-01-25 19:08:04"
+            "time": "2018-01-25T19:08:04+00:00"
         },
         {
             "name": "zendframework/zend-crypt",
@@ -5067,7 +5006,7 @@
                 "crypt",
                 "zf2"
             ],
-            "time": "2016-02-03 23:46:30"
+            "time": "2016-02-03T23:46:30+00:00"
         },
         {
             "name": "zendframework/zend-db",
@@ -5125,7 +5064,7 @@
                 "db",
                 "zf"
             ],
-            "time": "2019-02-25 12:07:35"
+            "time": "2019-02-25T12:07:35+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -5187,7 +5126,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2018-09-27 19:45:25"
+            "time": "2018-09-27T19:45:25+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -5232,7 +5171,7 @@
                 "escaper",
                 "zf"
             ],
-            "time": "2018-04-25 15:50:09"
+            "time": "2018-04-25T15:50:09+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -5286,7 +5225,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2019-04-10 14:21:50"
+            "time": "2019-04-10T14:21:50+00:00"
         },
         {
             "name": "zendframework/zend-filter",
@@ -5351,7 +5290,7 @@
                 "filter",
                 "zf"
             ],
-            "time": "2019-03-14 18:29:05"
+            "time": "2019-03-14T18:29:05+00:00"
         },
         {
             "name": "zendframework/zend-form",
@@ -5429,7 +5368,7 @@
                 "form",
                 "zf"
             ],
-            "time": "2018-12-11 22:51:29"
+            "time": "2018-12-11T22:51:29+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -5484,7 +5423,7 @@
                 "zend",
                 "zf"
             ],
-            "time": "2019-02-07 17:47:08"
+            "time": "2019-02-07T17:47:08+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
@@ -5542,7 +5481,7 @@
                 "hydrator",
                 "zf2"
             ],
-            "time": "2016-02-18 22:38:26"
+            "time": "2016-02-18T22:38:26+00:00"
         },
         {
             "name": "zendframework/zend-inputfilter",
@@ -5598,7 +5537,7 @@
                 "inputfilter",
                 "zf"
             ],
-            "time": "2017-12-04 21:24:25"
+            "time": "2017-12-04T21:24:25+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -5643,7 +5582,7 @@
                 "loader",
                 "zf"
             ],
-            "time": "2018-04-30 15:21:52"
+            "time": "2018-04-30T15:21:52+00:00"
         },
         {
             "name": "zendframework/zend-math",
@@ -5693,7 +5632,7 @@
                 "math",
                 "zf2"
             ],
-            "time": "2018-12-04 15:34:17"
+            "time": "2018-12-04T15:34:17+00:00"
         },
         {
             "name": "zendframework/zend-mvc",
@@ -5788,7 +5727,7 @@
                 "mvc",
                 "zf2"
             ],
-            "time": "2018-05-03 13:13:41"
+            "time": "2018-05-03T13:13:41+00:00"
         },
         {
             "name": "zendframework/zend-psr7bridge",
@@ -5837,7 +5776,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-05-10 21:44:39"
+            "time": "2016-05-10T21:44:39+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -5892,7 +5831,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-12-19 19:51:37"
+            "time": "2016-12-19T19:51:37+00:00"
         },
         {
             "name": "zendframework/zend-session",
@@ -5959,7 +5898,7 @@
                 "session",
                 "zf"
             ],
-            "time": "2018-02-22 16:28:39"
+            "time": "2018-02-22T16:28:39+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -6018,7 +5957,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12 21:17:31"
+            "time": "2016-04-12T21:17:31+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -6065,7 +6004,7 @@
                 "uri",
                 "zf"
             ],
-            "time": "2019-02-28 20:01:10"
+            "time": "2019-02-28T20:01:10+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -6138,7 +6077,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2019-01-29 22:26:39"
+            "time": "2019-01-29T22:26:39+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Description
Updates to new SDK 3.14.1

## Related Issue
Closes #455

## Motivation and Context
Magento Marketplace currently can't install the extension due to clashing dependencies versions with `vlucas/phpdotenv`. The new SDK allows a wider range of dependency versions.

## How Has This Been Tested?
Installed with Magento 2.3.1 locally

## Documentation:
N/A
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
