### PR TITLE
Hotfix/3.7.2 -  Fix wrong store issue when connecting account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.7.2
+* Get current store from store code param when connecting existing Nosto account
+
 ### 3.7.1
 * Fix issue in setting the marketing permission in customer tagging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### 3.7.2
 * Get current store from store code param when connecting existing Nosto account
+* Fix unclosed javascript method when Nosto autoload is enabled
 
 ### 3.7.1
 * Fix issue in setting the marketing permission in customer tagging

--- a/Controller/Oauth/Index.php
+++ b/Controller/Oauth/Index.php
@@ -47,6 +47,7 @@ use Nosto\OAuth;
 use Nosto\Tagging\Helper\Cache as NostoHelperCache;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+use Nosto\Tagging\Helper\Url as NostoHelperUrl;
 use Nosto\Tagging\Model\Meta\Oauth\Builder as NostoOauthBuilder;
 use Nosto\Types\Signup\AccountInterface;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
@@ -134,7 +135,9 @@ class Index extends Action
     public function save(AccountInterface $account)
     {
         $stores = $this->storeRepository->getList();
-        $storeCode = $this->request->getParam('___store');
+        $storeCode = $this->request->getParam(
+            NostoHelperUrl::MAGENTO_URL_PARAMETER_STORE
+        );
 
         if ($storeCode !== null) {
             $currentStore = $this->nostoHelperScope->getStoreByCode($storeCode);

--- a/Controller/Oauth/Index.php
+++ b/Controller/Oauth/Index.php
@@ -62,8 +62,10 @@ class Index extends Action
     private $nostoHelperScope;
     private $nostoHelperCache;
     private $storeRepository;
+    private $request;
 
     /**
+     * Index constructor.
      * @param Context $context
      * @param NostoLogger $logger
      * @param NostoHelperScope $nostoHelperScope
@@ -92,6 +94,7 @@ class Index extends Action
         $this->nostoHelperScope = $nostoHelperScope;
         $this->nostoHelperCache = $nostoHelperCache;
         $this->storeRepository = $storeRepository;
+        $this->request = $context->getRequest();
     }
 
     /**
@@ -131,7 +134,14 @@ class Index extends Action
     public function save(AccountInterface $account)
     {
         $stores = $this->storeRepository->getList();
-        $currentStore = $this->nostoHelperScope->getStore();
+        $storeCode = $this->request->getParam('___store');
+
+        if ($storeCode !== null) {
+            $currentStore = $this->nostoHelperScope->getStoreByCode($storeCode);
+        } else {
+            $currentStore = $this->nostoHelperScope->getStore();
+        }
+
         /** @var \Magento\Store\Model\Store $store */
         foreach ($stores as $store) {
             $existingAccount = $this->nostoHelperAccount->findAccount($store);
@@ -151,7 +161,7 @@ class Index extends Action
 
         $success =  $this->nostoHelperAccount->saveAccount(
             $account,
-            $this->nostoHelperScope->getStore()
+            $currentStore
         );
 
         // Invalidate cache after reconnected nosto account

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.7.1"/>
+    <module name="Nosto_Tagging" setup_version="3.7.2"/>
 </config>

--- a/view/frontend/templates/jsstub.phtml
+++ b/view/frontend/templates/jsstub.phtml
@@ -56,12 +56,12 @@
     (function () {
         var name = "nostojs";
         window[name] = window[name] || function (cb) {
-                (window[name].q = window[name].q || []).push(cb);
-            };
+            (window[name].q = window[name].q || []).push(cb);
+        };
         <?php if ($this->isRecoAutoloadDisabled()): ?>
         window[name](function(api){
             api.setAutoLoad(false);
         });
+        <?php endif; ?>
     })();
-    <?php endif; ?>
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Get current store trying to connect the account from store code, which is provided as a url parameter `?___store`

## Related Issue
closes #460

## Motivation and Context
Some merchant are having issues when connecting Nosto account, it get connected to the wrong store. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
