### PR TITLE
Bugfix - customer group id from session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### 3.7.3
 * Fix issue with add to cart controller where product from request could be null
+* Fetch the customer group directly from the session since the logged in check seems to fail when full page cahce is enabled
 
 ### 3.7.2
 * Get current store from store code param when connecting existing Nosto account

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -88,7 +88,7 @@ class Customer extends AbstractHelper
     {
         $groupId = $this->customerSession->getCustomerGroupId();
         if ($groupId && $groupId !== 0) {
-            return $this->customerSession->getCustomer()->getGroupId();
+            return $groupId;
         }
         return null;
     }

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -86,9 +86,8 @@ class Customer extends AbstractHelper
      */
     public function getGroupId()
     {
-        if ($this->customerSession->isLoggedIn()
-            && $this->customerSession->getCustomer()
-        ) {
+        $groupId = $this->customerSession->getCustomerGroupId();
+        if ($groupId && $groupId !== 0) {
             return $this->customerSession->getCustomer()->getGroupId();
         }
         return null;


### PR DESCRIPTION
Logged in customer check fails in block level when full page cache is enabled. Changed the logic to use the customer group id from the session directly. 

## Description
Remove `isLoggedIn` check from customer helper and fetch the customer group id directly from the session.

## Related Issue
#469 

## Motivation and Context
The recos are loaded twice if the customer group is not set on block level.

## How Has This Been Tested?
Tested locally with FPC on and off. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
