### PR TITLE
Fix possible method call on null when order sending to Nosto fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.7.4
+* Fix issue with trying to call method on null when order confirmation observer fails
+
 ### 3.7.3
 * Fix issue with add to cart controller where product from request could be null
 * Fetch the customer group directly from the session since the logged in check seems to fail when full page cahce is enabled

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -157,7 +157,7 @@ class Save implements ObserverInterface
                             'Failed to save order with quote #%s for customer #%s.
                         Message was: %s',
                             $quoteId,
-                            $nostoCustomer->getNostoId(),
+                            $nostoCustomerId,
                             $e->getMessage()
                         )
                     );

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -157,7 +157,7 @@ class Save implements ObserverInterface
                             'Failed to save order with quote #%s for customer #%s.
                         Message was: %s',
                             $quoteId,
-                            $nostoCustomerId,
+                            (string)$nostoCustomerId,
                             $e->getMessage()
                         )
                     );

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.7.3"/>
+    <module name="Nosto_Tagging" setup_version="3.7.4"/>
 </config>


### PR DESCRIPTION
Fix possible method call on null in order confirmation.

## Description
Don't call methods on `$nostoCustomer` since it might be null 

## Related Issue
#476 

## Motivation and Context
It causes fatal error if the order confirmation sending to Nosto fails and Nosto customer is not defined. 

## How Has This Been Tested?
Tested locally

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
