### PR TITLE
Remove product cache flushing after upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.7.5
+* Remove product cache flushing after upsert to avoid failures in altering product categories
+
 ### 3.7.4
 * Fix issue with trying to call method on null when order confirmation observer fails
 

--- a/Model/Product/Service.php
+++ b/Model/Product/Service.php
@@ -399,18 +399,7 @@ class Service
             $op->clearCollection();
         }
         $this->logger->logWithMemoryConsumption('After Upsert sent');
-
-        try {
-            // Magento internally cache those queries
-            // Enforce cleaning of this as much as possible
-            foreach ($productsStillExist as $product) {
-                $product->clearInstance();
-            }
-        } catch (\Exception $e) {
-            $this->logger->exception($e);
-        }
         $productSearch->setItems([]);
-
         $batchEndMem = Memory::getConsumption(false);
         $this->logger->logWithMemoryConsumption(
             sprintf(

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.7.4"/>
+    <module name="Nosto_Tagging" setup_version="3.7.5"/>
 </config>


### PR DESCRIPTION
Remove product cache flushing after we've sent product updates to Nosto.

## Related Issue
#475 

## Motivation and Context
Clearing the Magento's internal product caches can cause consecutive updates / event processors to fail.  

## How Has This Been Tested?
Tested locally with versions 2.2.6 and 2.3.1

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
