### PR TITLE
Hotfix 3.8.2 - Ratings Helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.2
+* Fix issue that could crash a product page when using enabling Magento native reviews in Nosto settings 
+
 ### 3.8.1
 * Fix version comparison on data upgrading
 

--- a/Helper/Ratings.php
+++ b/Helper/Ratings.php
@@ -45,6 +45,7 @@ use Magento\Store\Model\Store;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Magento\Review\Model\ReviewFactory;
 use Nosto\Tagging\Model\Product\Ratings as ProductRatings;
+use Magento\Framework\DataObject;
 
 /**
  * Rating helper used for product rating related tasks.
@@ -171,15 +172,21 @@ class Ratings extends AbstractHelper
      */
     private function buildRatingValue(Product $product, Store $store)
     {
-        if (!$product->hasData('rating_summary')) {
+        /** @noinspection PhpUndefinedMethodInspection */
+        if (!$product->getRatingSummary()) {
             // getEntitySummary also sets the ratingSummary into the given product
             $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
         }
-
-        if ($product->getData('rating_summary') > 0) {
-            return round($product->getData('rating_summary') / 20, 1);
+        /** @noinspection PhpUndefinedMethodInspection */
+        $ratingSummaryObj = $product->getRatingSummary();
+        if ($ratingSummaryObj instanceof DataObject) {
+            /** @noinspection PhpUndefinedMethodInspection */
+            return round($ratingSummaryObj->getRatingSummary() / 20, 1);
         }
-
+        // After Magento 2.3.1 getRatingSummary() returns a string.
+        if (!empty($ratingSummaryObj)) {
+            return round($ratingSummaryObj / 20, 1);
+        }
         return null;
     }
 
@@ -193,20 +200,25 @@ class Ratings extends AbstractHelper
      */
     private function buildReviewCount(Product $product, Store $store)
     {
-        if (!$product->getData('rating_summary')) {
+        /** @noinspection PhpUndefinedMethodInspection */
+        if (!$product->getRatingSummary()) {
             // getEntitySummary also sets the ratingSummary into the given product
             $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
         }
 
-        if ($product->getData('reviews_count') > 0) {
-            return $product->getData('reviews_count');
+        /** @noinspection PhpUndefinedMethodInspection */
+        $ratingSummaryObj = $product->getRatingSummary();
+        /** @noinspection PhpUndefinedMethodInspection */
+        if ($ratingSummaryObj instanceof DataObject && $ratingSummaryObj->getReviewsCount() > 0) {
+            /** @noinspection PhpUndefinedMethodInspection */
+            return $ratingSummaryObj->getReviewsCount();
         }
-
-        return null;
+        /** @noinspection PhpUndefinedMethodInspection */
+        return $product->getReviewsCount();
     }
 
     /**
-     * Check if Yopto module is enabled and has getRichSnippet method
+     * Check if Yotpo module is enabled and has getRichSnippet method
      *
      * @return bool
      */

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.8.1"/>
+    <module name="Nosto_Tagging" setup_version="3.8.2"/>
 </config>


### PR DESCRIPTION
## Description
- Refactor Ratings Helper
- Uses getData instead of magic getters
- Fix an issue where we could call a function from a string when using `$product->getRatingSummary()` crashing the product detail page.

## Related Issue
Fixes #488 

## Motivation and Context
When using Magento native reviews enabled in Nosto settings as well, the product detail page would crash.

## How Has This Been Tested?
- [x] Module Yotpo Reviews return the correct review count and summary
- [x] Magento Reviews return the correct review count and summary

## Documentation:
N/A

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
