### PR TITLE
Hotfix 3.8.2 - Fix redirect uri for multistore setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.2
+* Fix redirect_uri for multi-store setup with different domains
+
 ### 3.8.1
 * Fix version comparison on data upgrading
 

--- a/Model/Meta/Oauth/Builder.php
+++ b/Model/Meta/Oauth/Builder.php
@@ -91,6 +91,7 @@ class Builder
                 [
                     '_nosid' => true,
                     '_scope_to_url' => $this->nostoHelperData->getStoreCodeToUrl($store),
+                    '_scope' => $store->getCode(),
                     '_query' => ['___store' => $store->getCode()]
                 ]
             );

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.8.1"/>
+    <module name="Nosto_Tagging" setup_version="3.8.2"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Get the correct store domain in case the store domain is different from the magento's one. 

## Related Issue
closes #490

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
