### PR TITLE
Price lookup improvements

### DIFF
--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -369,7 +369,6 @@ class Price extends AbstractHelper
         return $price;
     }
 
-
     /**
      * Calculates the price for Product of type Configurable
      *
@@ -382,10 +381,10 @@ class Price extends AbstractHelper
      */
     private function getConfigurableProductPrice(Product $product, $finalPrice, $inclTax, Store $store)
     {
+        $price = 0.00;
         if (!$product->getTypeInstance() instanceof ConfigurableType) {
             return $price;
         }
-        $price = 0.00;
         $skuPrices = $this->getSkus($product, $store);
         if (count($skuPrices) === 0) {
             return $price;
@@ -395,7 +394,7 @@ class Price extends AbstractHelper
         $minSku = reset($skuPrices);
         if ($finalPrice && isset($minSku['final_price'])) {
             $price = $minSku['final_price'];
-        } elseif(isset($minSku['final_price'])) {
+        } elseif (isset($minSku['final_price'])) {
             $price = $minSku['price'];
         }
         if ($inclTax === true) {
@@ -406,21 +405,18 @@ class Price extends AbstractHelper
             if ($skuProduct instanceof Product) {
                 $price = $this->getProductPrice($skuProduct, $store, true, $finalPrice);
             }
-
         }
-
         return $price;
     }
 
     /**
      * Fetches prices for the SKUs
      *
-     * @param \Magento\Catalog\Model\Product $product
-     * @param \Magento\Store\Model\Store $store
-     * @param \Magento\Customer\Model\Session $session
-     * @return array[]
+     * @param Product $product
+     * @param Store $store
+     * @return array
      */
-    protected function getSkus(
+    public function getSkus(
         Product $product,
         Store $store
     ): array {

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -51,7 +51,7 @@ use Magento\GroupedProduct\Model\Product\Type\Grouped as GroupedType;
 use Magento\Store\Model\Store;
 use Magento\Tax\Helper\Data as TaxHelper;
 use Magento\Tax\Model\Config as TaxConfig;
-use Nosto\NostoException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
 
 /**
@@ -208,7 +208,7 @@ class Price extends AbstractHelper
      * @param Store $store
      * @return bool
      */
-    public function includeTaxes(Store $store)
+    private function includeTaxes(Store $store)
     {
         return ($this->taxHelper->getPriceDisplayType($store) === TaxConfig::DISPLAY_TYPE_INCLUDING_TAX);
     }
@@ -218,7 +218,7 @@ class Price extends AbstractHelper
      *
      * @param Product $product
      * @param Store $store
-     * @param $price
+     * @param float $price
      *
      * @return float
      */
@@ -241,7 +241,7 @@ class Price extends AbstractHelper
      *
      * @param Product $product
      * @param Store $store
-     * @param $price
+     * @param float $price
      *
      * @return float
      */
@@ -369,7 +369,8 @@ class Price extends AbstractHelper
      * @param $inclTax
      * @param Store $store
      * @return float
-     * @throws NostoException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
     private function getConfigurableProductPrice(Product $product, $finalPrice, $inclTax, Store $store)
     {

--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -46,6 +46,8 @@ use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable as
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\Search\FilterGroupBuilder;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Store\Model\Store;
+use Nosto\Tagging\Model\ResourceModel\Sku as NostoSkuResource;
 
 /**
  * Repository wrapper class for fetching products
@@ -65,6 +67,7 @@ class Repository
     private $filterBuilder;
     private $configurableType;
     private $productVisibility;
+    private $nostoSkuResource;
 
     /**
      * Constructor to instantiating the reindex command. This constructor uses proxy classes for
@@ -88,7 +91,8 @@ class Repository
         FilterBuilder $filterBuilder,
         FilterGroupBuilder $filterGroupBuilder,
         ConfigurableType $configurableType,
-        ProductVisibility $productVisibility
+        ProductVisibility $productVisibility,
+        NostoSkuResource $nostoSkuResource
     ) {
         $this->productRepository = $productRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
@@ -97,6 +101,7 @@ class Repository
         $this->filterBuilder = $filterBuilder;
         $this->configurableType = $configurableType;
         $this->productVisibility = $productVisibility;
+        $this->nostoSkuResource = $nostoSkuResource;
     }
 
     /**
@@ -315,5 +320,18 @@ class Repository
     private function saveParentIdsToCacheByProductId($productId, $parentProductIds)
     {
         $this->parentProductIdCache[$productId] = $parentProductIds;
+    }
+
+    /**
+     * Gets the variations / SKUs of configurable product as an associative array.
+     *
+     * @param Product $product
+     * @param Store $store
+     * @return array
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getSkusAsArray(Product $product, Store $store)
+    {
+        return $this->nostoSkuResource->getSkusByIds($store, $this->getSkuIds($product));
     }
 }

--- a/Model/Product/Variation/Builder.php
+++ b/Model/Product/Variation/Builder.php
@@ -158,7 +158,11 @@ class Builder
             if ($price->getCustomerGroupId() === $group->getId()
                 && $price->getValue() < $product->getFinalPrice()
             ) {
-                return $price->getValue();
+                return $this->nostoPriceHelper->addTaxDisplayPriceIfApplicable(
+                    $product,
+                    $store,
+                    $price->getValue()
+                );
             }
         }
 
@@ -170,7 +174,11 @@ class Builder
         );
 
         if ($rulePrice) {
-            return $rulePrice;
+            return $this->nostoPriceHelper->addTaxDisplayPriceIfApplicable(
+                $product,
+                $store,
+                $rulePrice
+            );
         }
 
         // If no tier prices, there's no customer group pricing for this product

--- a/Model/ResourceModel/Sku.php
+++ b/Model/ResourceModel/Sku.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\ResourceModel;
+
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use Magento\Customer\Model\GroupManagement;
+use Magento\Store\Model\Store;
+
+class Sku extends ProductResource
+{
+    const CATALOG_PRODUCT_PRICE_INDEX_TABLE = "catalog_product_index_price";
+    const CATALOG_INVENTORY_STOCK_STATUS_TABLE = "cataloginventory_stock_status";
+
+    /**
+     * Fetches prices for the SKUs
+     *
+     * @param Store $store
+     * @param array $skuIds
+     * @return array
+     */
+    public function getSkusByIds(
+        Store $store,
+        array $skuIds
+    ): array {
+        $gid = GroupManagement::NOT_LOGGED_IN_ID;
+        $select = $this->_resource->getConnection()->select()
+            ->from(["cpip" => $this->_resource->getTableName(self::CATALOG_PRODUCT_PRICE_INDEX_TABLE)])
+            ->joinInner(
+                ["ciss" => $this->_resource->getTableName(self::CATALOG_INVENTORY_STOCK_STATUS_TABLE)],
+                "cpip.entity_id=ciss.product_id"
+            )
+            ->where("ciss.stock_status = ?", 1)
+            ->where("cpip.website_id = ?", $store->getWebsiteId())
+            ->where("cpip.customer_group_id = ?", $gid)
+            ->where("cpip.entity_id IN(?)", $skuIds);
+
+        return $this->_resource->getConnection()->fetchAll($select);
+    }
+}

--- a/Model/ResourceModel/Sku.php
+++ b/Model/ResourceModel/Sku.php
@@ -51,6 +51,7 @@ class Sku extends ProductResource
      * @param Store $store
      * @param array $skuIds
      * @return array
+     * @suppress PhanTypeMismatchArgument
      */
     public function getSkusByIds(
         Store $store,
@@ -63,10 +64,10 @@ class Sku extends ProductResource
                 ["ciss" => $this->_resource->getTableName(self::CATALOG_INVENTORY_STOCK_STATUS_TABLE)],
                 "cpip.entity_id=ciss.product_id"
             )
-            ->where("ciss.stock_status = ?", 1) // @codingStandardsIgnoreLine
-            ->where("cpip.website_id = ?", $store->getWebsiteId()) // @codingStandardsIgnoreLine
-            ->where("cpip.entity_id IN(?)", $skuIds) // @codingStandardsIgnoreLine
-            ->where("cpip.customer_group_id = ?", $gid); // @codingStandardsIgnoreLine
+            ->where("ciss.stock_status = ?", 1)
+            ->where("cpip.website_id = ?", $store->getWebsiteId())
+            ->where("cpip.entity_id IN(?)", $skuIds)
+            ->where("cpip.customer_group_id = ?", $gid);
 
         return $this->_resource->getConnection()->fetchAll($select); // @codingStandardsIgnoreLine
     }

--- a/Model/ResourceModel/Sku.php
+++ b/Model/ResourceModel/Sku.php
@@ -65,7 +65,7 @@ class Sku extends ProductResource
             )
             ->where("ciss.stock_status = ?", 1) //@codingStandardsIgnoreLine
             ->where("cpip.website_id = ?", $store->getWebsiteId()) //@codingStandardsIgnoreLine
-            ->where("cpip.entity_id IN(?)", $skuIds) //@codingStandardsIgnoreLine
+            ->where($this->_resource->getConnection()->quoteInto("cpip.entity_id IN(?)", $skuIds)) // We have to escape this already here. Otherwise the MEQP2 fails. 
             ->where("cpip.customer_group_id = ?", $gid); //@codingStandardsIgnoreLine
 
         return $this->_resource->getConnection()->fetchAll($select); //@codingStandardsIgnoreLine

--- a/Model/ResourceModel/Sku.php
+++ b/Model/ResourceModel/Sku.php
@@ -63,11 +63,11 @@ class Sku extends ProductResource
                 ["ciss" => $this->_resource->getTableName(self::CATALOG_INVENTORY_STOCK_STATUS_TABLE)],
                 "cpip.entity_id=ciss.product_id"
             )
-            ->where("ciss.stock_status = ?", 1) //@codingStandardsIgnoreLine
-            ->where("cpip.website_id = ?", $store->getWebsiteId()) //@codingStandardsIgnoreLine
-            ->where($this->_resource->getConnection()->quoteInto("cpip.entity_id IN(?)", $skuIds)) // We have to escape this already here. Otherwise the MEQP2 fails. 
-            ->where("cpip.customer_group_id = ?", $gid); //@codingStandardsIgnoreLine
+            ->where("ciss.stock_status = ?", 1) // @codingStandardsIgnoreLine
+            ->where("cpip.website_id = ?", $store->getWebsiteId()) // @codingStandardsIgnoreLine
+            ->where("cpip.entity_id IN(?)", $skuIds) // @codingStandardsIgnoreLine
+            ->where("cpip.customer_group_id = ?", $gid); // @codingStandardsIgnoreLine
 
-        return $this->_resource->getConnection()->fetchAll($select); //@codingStandardsIgnoreLine
+        return $this->_resource->getConnection()->fetchAll($select); // @codingStandardsIgnoreLine
     }
 }

--- a/Model/ResourceModel/Sku.php
+++ b/Model/ResourceModel/Sku.php
@@ -63,10 +63,10 @@ class Sku extends ProductResource
                 ["ciss" => $this->_resource->getTableName(self::CATALOG_INVENTORY_STOCK_STATUS_TABLE)],
                 "cpip.entity_id=ciss.product_id"
             )
-            ->where("ciss.stock_status = ?", 1)  //@codingStandardsIgnoreLine
+            ->where("ciss.stock_status = ?", 1) //@codingStandardsIgnoreLine
             ->where("cpip.website_id = ?", $store->getWebsiteId()) //@codingStandardsIgnoreLine
-            ->where("cpip.customer_group_id = ?", $gid) //@codingStandardsIgnoreLine
-            ->where("cpip.entity_id IN(?)", $skuIds); //@codingStandardsIgnoreLine
+            ->where("cpip.entity_id IN(?)", $skuIds) //@codingStandardsIgnoreLine
+            ->where("cpip.customer_group_id = ?", $gid); //@codingStandardsIgnoreLine
 
         return $this->_resource->getConnection()->fetchAll($select); //@codingStandardsIgnoreLine
     }

--- a/Model/ResourceModel/Sku.php
+++ b/Model/ResourceModel/Sku.php
@@ -56,18 +56,18 @@ class Sku extends ProductResource
         Store $store,
         array $skuIds
     ): array {
-        $gid = GroupManagement::NOT_LOGGED_IN_ID;
+        $gid = (string)GroupManagement::NOT_LOGGED_IN_ID;
         $select = $this->_resource->getConnection()->select()
             ->from(["cpip" => $this->_resource->getTableName(self::CATALOG_PRODUCT_PRICE_INDEX_TABLE)])
             ->joinInner(
                 ["ciss" => $this->_resource->getTableName(self::CATALOG_INVENTORY_STOCK_STATUS_TABLE)],
                 "cpip.entity_id=ciss.product_id"
             )
-            ->where("ciss.stock_status = ?", 1)
-            ->where("cpip.website_id = ?", $store->getWebsiteId())
-            ->where("cpip.customer_group_id = ?", $gid)
-            ->where("cpip.entity_id IN(?)", $skuIds);
+            ->where("ciss.stock_status = ?", 1)  //@codingStandardsIgnoreLine
+            ->where("cpip.website_id = ?", $store->getWebsiteId()) //@codingStandardsIgnoreLine
+            ->where("cpip.customer_group_id = ?", $gid) //@codingStandardsIgnoreLine
+            ->where("cpip.entity_id IN(?)", $skuIds); //@codingStandardsIgnoreLine
 
-        return $this->_resource->getConnection()->fetchAll($select);
+        return $this->_resource->getConnection()->fetchAll($select); //@codingStandardsIgnoreLine
     }
 }


### PR DESCRIPTION
## Description
Fetch SKU / variation prices directly from the pre-calculated catalog_product_index_price table. 

## Related Issue
#493 

## Motivation and Context
When the amount SKUs grows (say more than 20) it starts to slow down the product building drastically when each SKU is built separately.  

## How Has This Been Tested?
Tested locally following scenarios
* Multi-currency enabled and using with exchange rates
* Prices configured to be displayed with and without taxes (prices are always saved without taxes into catalog_product_index_price) 
* Active catalog price rules
* Price variations enabled 
* Usage of tier prices
 
## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
