### PR TITLE
Fix Nosto product sync indexer's executeFull method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.4
+* Fix Nosto indexer's full reindex logic 
+
 ### 3.8.3
 * Fix parent product resolving for SKUs in product service
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.8.3"/>
+    <module name="Nosto_Tagging" setup_version="3.8.4"/>
 </config>


### PR DESCRIPTION
Full reindex was throwing fatal error due to the wrong attribute type after the last indexer fix. 

## Description
Change the `Indexer::executeFull` to use array of Product objects rather than array of product ids. 

## Related Issue
#510 

## Motivation and Context
Running `bin/magento indexer:reindex nosto_product_sync` was broken.

## How Has This Been Tested?
Tested locally to run the full reindex

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
