### PR TITLE
Remove proxies from constructors and use di.xml to define them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.5
+* Remove proxy classes from constructors to be in accordance with Magento marketplace code review
+
 ### 3.8.4
 * Fix Nosto indexer's full reindex logic 
 

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -39,7 +39,6 @@ namespace Nosto\Tagging\Helper;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Customer\Api\GroupRepositoryInterface as GroupRepository;
 use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Customer\Model\GroupManagement;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
@@ -60,7 +59,7 @@ class Customer extends AbstractHelper
      * @param GroupRepository $groupRepository
      */
     public function __construct(
-        CustomerSession $customerSession,
+        CustomerSession $customerSession, // @codingStandardsIgnoreLine
         GroupRepository $groupRepository
     ) {
         $this->customerSession = $customerSession;

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -38,7 +38,7 @@ namespace Nosto\Tagging\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Customer\Api\GroupRepositoryInterface as GroupRepository;
-use Magento\Customer\Model\Session\Proxy as CustomerSession;
+use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Customer\Model\GroupManagement;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;

--- a/Model/Indexer/Product/Indexer.php
+++ b/Model/Indexer/Product/Indexer.php
@@ -72,7 +72,7 @@ class Indexer implements IndexerActionInterface, MviewActionInterface
      * @param NostoLogger $logger
      * @param ProductCollectionFactory $productCollectionFactory
      * @param NostoQueueRepository $nostoQueueRepository
-     * @param NostoHelperAccount\Proxy $nostoHelperAccount
+     * @param NostoHelperAccount $nostoHelperAccount
      */
     public function __construct(
         ProductService $productService,
@@ -80,7 +80,7 @@ class Indexer implements IndexerActionInterface, MviewActionInterface
         NostoLogger $logger,
         ProductCollectionFactory $productCollectionFactory,
         NostoQueueRepository $nostoQueueRepository,
-        NostoHelperAccount\Proxy $nostoHelperAccount
+        NostoHelperAccount $nostoHelperAccount
     ) {
         $this->productService = $productService;
         $this->dataHelper = $dataHelper;

--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -72,7 +72,7 @@ class Repository
      * Not using the proxy classes will lead to a "Area code not set" exception being thrown in the
      * compile phase.
      *
-     * @param ProductRepository\Proxy $productRepository
+     * @param ProductRepository $productRepository
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param ConfigurableProduct $configurableProduct
      * @param FilterBuilder $filterBuilder
@@ -81,7 +81,7 @@ class Repository
      * @param ProductVisibility $productVisibility
      */
     public function __construct(
-        ProductRepository\Proxy $productRepository,
+        ProductRepository $productRepository,
         SearchCriteriaBuilder $searchCriteriaBuilder,
         ConfigurableProduct $configurableProduct,
         FilterBuilder $filterBuilder,

--- a/Model/Product/Service.php
+++ b/Model/Product/Service.php
@@ -89,8 +89,8 @@ class Service
      * compile phase.
      * @param NostoLogger $logger
      * @param Builder $nostoProductBuilder
-     * @param NostoHelperAccount\Proxy $nostoHelperAccount
-     * @param NostoHelperData\Proxy $nostoHelperData
+     * @param NostoHelperAccount $nostoHelperAccount
+     * @param NostoHelperData $nostoHelperData
      * @param NostoProductRepository $nostoProductRepository
      * @param QueueRepository $nostoQueueRepository
      * @param QueueFactory $nostoQueueFactory
@@ -102,8 +102,8 @@ class Service
     public function __construct(
         NostoLogger $logger,
         NostoProductBuilder $nostoProductBuilder,
-        NostoHelperAccount\Proxy $nostoHelperAccount,
-        NostoHelperData\Proxy $nostoHelperData,
+        NostoHelperAccount $nostoHelperAccount,
+        NostoHelperData $nostoHelperData,
         NostoProductRepository $nostoProductRepository,
         QueueRepository $nostoQueueRepository,
         QueueFactory $nostoQueueFactory,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -84,4 +84,25 @@
     <type name="Magento\Sales\Api\OrderRepositoryInterface">
         <plugin name="order_repository_nosto" type="Nosto\Tagging\Plugin\Sales\OrderRepository" />
     </type>
+    <type name="Nosto\Tagging\Model\Product\Repository">
+        <arguments>
+            <argument name="productRepository" xsi:type="object">Magento\Catalog\Model\ProductRepository\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Nosto\Tagging\Model\Product\Service">
+        <arguments>
+            <argument name="nostoHelperAccount" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+            <argument name="nostoHelperData" xsi:type="object">Nosto\Tagging\Helper\Data\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Nosto\Tagging\Model\Indexer\Product\Indexer">
+        <arguments>
+            <argument name="nostoHelperAccount" xsi:type="object">Nosto\Tagging\Helper\Account\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Nosto\Tagging\Helper\Customer">
+        <arguments>
+            <argument name="customerSession" xsi:type="object">Magento\Customer\Model\Session\Proxy</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.8.4"/>
+    <module name="Nosto_Tagging" setup_version="3.8.5"/>
 </config>


### PR DESCRIPTION
## Description
This removes those proxy classes and set them as a proxy on the `di.xml` file

## Related Issue
Fixes #527 

## Motivation and Context
Magento marketplace code review is complaining about the use of proxy classes directly on constructors.

## How Has This Been Tested?
- [x] Locally with Magento 2.3.2

## Documentation:
N/A

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
