### PR TITLE
Remove array constructor comparison from recobuy addMultipleProductsT…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.6
+* Fix add to cart array comparison
+
 ### 3.8.5
 * Remove proxy classes from constructors to be in accordance with Magento marketplace code review
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.8.5"/>
+    <module name="Nosto_Tagging" setup_version="3.8.6"/>
 </config>

--- a/view/frontend/web/js/recobuy.js
+++ b/view/frontend/web/js/recobuy.js
@@ -55,9 +55,11 @@ define([
     // Products must be and array of objects [{'productId': '123', 'skuId': '321'}, {...}]
     // skuId is optional for simple products.
     Recobuy.addMultipleProductsToCart = function (products, element) {
-        products.forEach(function (productObj) {
-            Recobuy.addSkuToCart(productObj, element, 1);
-        });
+        if (Array.isArray(products)) {
+            products.forEach(function (productObj) {
+                Recobuy.addSkuToCart(productObj, element, 1);
+            });
+        }
     };
 
     // Product object must have fields productId and skuId {'productId': '123', 'skuId': '321'}

--- a/view/frontend/web/js/recobuy.js
+++ b/view/frontend/web/js/recobuy.js
@@ -55,11 +55,9 @@ define([
     // Products must be and array of objects [{'productId': '123', 'skuId': '321'}, {...}]
     // skuId is optional for simple products.
     Recobuy.addMultipleProductsToCart = function (products, element) {
-        if (products.constructor === Array) {
-            products.forEach(function (productObj) {
-                Recobuy.addSkuToCart(productObj, element, 1);
-            });
-        }
+        products.forEach(function (productObj) {
+            Recobuy.addSkuToCart(productObj, element, 1);
+        });
     };
 
     // Product object must have fields productId and skuId {'productId': '123', 'skuId': '321'}


### PR DESCRIPTION
## Description
Remove array constructor comparison from recobuy addMultipleProductsToCart. This does not work from one target window to another.
As a reference, see:
https://stackoverflow.com/questions/28467266/can-i-use-obj-constructor-array-to-test-if-object-is-array/28467392#28467392

## Related Issue
Fixes #534

## Motivation and Context
Some merchants using bundle recommendation slots are having issues adding them to cart from our reco slots.

## How Has This Been Tested?
Tested both in plugintest environment and locally using this template:
https://gist.github.com/supercid/a1b8fff164db5abd2c418385c1b36db3

## Documentation:
Unchanged

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities