### PR TITLE
Hotfix - Product availability on single store mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.7
+* Fix product availability when in single store mode
+
 ### 3.8.6
 * Fix add to cart array comparison
 

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -400,12 +400,13 @@ class Builder
     private function buildAvailability(Product $product, Store $store)
     {
         $availability = ProductInterface::OUT_OF_STOCK;
+        $isInStock = $this->isInStock($product, $store);
         if (!$product->isVisibleInSiteVisibility()
-            || (!$this->isAvailableInStore($product, $store) && $this->isInStock($product, $store))
+            || (!$this->isAvailableInStore($product, $store) && $isInStock)
         ) {
             $availability = ProductInterface::INVISIBLE;
-        } elseif ($product->isAvailable()
-            && $this->isInStock($product, $store)
+        } elseif ($isInStock
+            && $product->isAvailable()
         ) {
             $availability = ProductInterface::IN_STOCK;
         }

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -60,6 +60,7 @@ use Nosto\Object\ModelFilter;
 use Nosto\Tagging\Model\Product\Variation\Collection as PriceVariationCollection;
 use Nosto\Tagging\Helper\Variation as NostoVariationHelper;
 use Nosto\Tagging\Helper\Ratings as NostoRating;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Builder
 {
@@ -110,6 +111,7 @@ class Builder
      * @param PriceVariationCollection $priceVariationCollection
      * @param NostoVariationHelper $nostoVariationHelper
      * @param NostoRating $nostoRatingHelper
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         NostoHelperData $nostoHelperData,
@@ -129,7 +131,8 @@ class Builder
         StockRegistryInterface $stockRegistry,
         PriceVariationCollection $priceVariationCollection,
         NostoVariationHelper $nostoVariationHelper,
-        NostoRating $nostoRatingHelper
+        NostoRating $nostoRatingHelper,
+        StoreManagerInterface $storeManager
     ) {
         $this->nostoDataHelper = $nostoHelperData;
         $this->nostoPriceHelper = $priceHelper;
@@ -148,7 +151,8 @@ class Builder
         $this->builderTraitConstruct(
             $nostoHelperData,
             $stockRegistry,
-            $logger
+            $logger,
+            $storeManager
         );
         $this->priceVariationCollection = $priceVariationCollection;
         $this->nostoVariationHelper = $nostoVariationHelper;
@@ -397,7 +401,7 @@ class Builder
     {
         $availability = ProductInterface::OUT_OF_STOCK;
         if (!$product->isVisibleInSiteVisibility()
-            || !$this->isAvailabeInStore($product, $store)
+            || !$this->isAvailableInStore($product, $store)
         ) {
             $availability = ProductInterface::INVISIBLE;
         } elseif ($product->isAvailable()

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -401,7 +401,7 @@ class Builder
     {
         $availability = ProductInterface::OUT_OF_STOCK;
         if (!$product->isVisibleInSiteVisibility()
-            || !$this->isAvailableInStore($product, $store)
+            || (!$this->isAvailableInStore($product, $store) && $this->isInStock($product, $store))
         ) {
             $availability = ProductInterface::INVISIBLE;
         } elseif ($product->isAvailable()

--- a/Model/Product/BuilderTrait.php
+++ b/Model/Product/BuilderTrait.php
@@ -46,25 +46,31 @@ use Nosto\Tagging\Helper\Data as NostoHelperData;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Util\Url as UrlUtil;
 use Nosto\Helper\ArrayHelper;
+use Magento\Store\Model\StoreManagerInterface;
 
 trait BuilderTrait
 {
     private $nostoDataHelperTrait;
     private $loggerTrait;
     private $stockRegistry;
+    private $storeManager;
 
     /**
      * @param NostoHelperData $nostoHelperData
+     * @param StockRegistryInterface $stockRegistry
      * @param NostoLogger $logger
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         NostoHelperData $nostoHelperData,
         StockRegistryInterface $stockRegistry,
-        NostoLogger $logger
+        NostoLogger $logger,
+        StoreManagerInterface $storeManager
     ) {
         $this->nostoDataHelperTrait = $nostoHelperData;
         $this->stockRegistry = $stockRegistry;
         $this->loggerTrait = $logger;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -191,9 +197,12 @@ trait BuilderTrait
      * @param Store $store
      * @return bool
      */
-    public function isAvailabeInStore(Product $product, Store $store)
+    public function isAvailableInStore(Product $product, Store $store)
     {
-        return in_array($store->getId(), $product->getStoreIds());
+        if ($this->storeManager->isSingleStoreMode()) {
+            return $product->isAvailable();
+        }
+        return in_array($store->getId(), $product->getStoreIds(), false);
     }
 
     /**

--- a/Model/Product/Sku/Builder.php
+++ b/Model/Product/Sku/Builder.php
@@ -51,6 +51,7 @@ use Nosto\Tagging\Model\Product\BuilderTrait;
 use Nosto\Types\Product\ProductInterface;
 use Nosto\Tagging\Model\Product\Builder as NostoProductBuilder;
 use Nosto\Tagging\Helper\Stock as NostoStockHelper;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Builder
 {
@@ -70,7 +71,9 @@ class Builder
      * @param NostoLogger $logger
      * @param ManagerInterface $eventManager
      * @param CurrencyHelper $nostoCurrencyHelper
+     * @param StockRegistryInterface $stockRegistry
      * @param NostoStockHelper $stockHelper
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         NostoHelperData $nostoHelperData,
@@ -79,7 +82,8 @@ class Builder
         ManagerInterface $eventManager,
         CurrencyHelper $nostoCurrencyHelper,
         StockRegistryInterface $stockRegistry,
-        NostoStockHelper $stockHelper
+        NostoStockHelper $stockHelper,
+        StoreManagerInterface $storeManager
     ) {
         $this->nostoDataHelper = $nostoHelperData;
         $this->nostoPriceHelper = $priceHelper;
@@ -90,7 +94,8 @@ class Builder
         $this->builderTraitConstruct(
             $nostoHelperData,
             $stockRegistry,
-            $logger
+            $logger,
+            $storeManager
         );
     }
 
@@ -107,7 +112,7 @@ class Builder
         $attributes,
         $nostoScope = NostoProductBuilder::NOSTO_SCOPE_API
     ) {
-        if (!$this->isAvailabeInStore($product, $store)) {
+        if (!$this->isAvailableInStore($product, $store)) {
             return null;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.8.6"/>
+    <module name="Nosto_Tagging" setup_version="3.8.7"/>
 </config>


### PR DESCRIPTION
## Description
Fixes Products build availability when in single store mode.
## Related Issue
Fixes #502 

## Motivation and Context
When using Magento in single store mode, all products are marked as Invisible, this PR fix this issue

## How Has This Been Tested?
Locally With Magento 2.3 with:
- [X] Configurable products and its SKU's;
- [X] Single Products;
- [X] Grouped Products.

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
