### PR TITLE
Refactor logic for checking where the full reindex is called

### DIFF
--- a/Model/Indexer/Invalidate.php
+++ b/Model/Indexer/Invalidate.php
@@ -46,6 +46,7 @@ use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductColle
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionFactory as ProductCollectionFactory;
 use Nosto\Tagging\Model\Service\Index as NostoServiceIndex;
 use Nosto\Tagging\Util\Indexer as IndexerUtil;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Class Invalidate
@@ -66,6 +67,9 @@ class Invalidate implements IndexerActionInterface, MviewActionInterface
     /** @var ProductCollectionFactory */
     private $productCollectionFactory;
 
+    /** @var InputInterface */
+    private $input;
+
     /**
      * Dirty constructor.
      * @param NostoHelperAccount $nostoHelperAccount
@@ -75,11 +79,13 @@ class Invalidate implements IndexerActionInterface, MviewActionInterface
     public function __construct(
         NostoHelperAccount $nostoHelperAccount,
         NostoServiceIndex $nostoServiceIndex,
-        ProductCollectionFactory $productCollectionFactory
+        ProductCollectionFactory $productCollectionFactory,
+        InputInterface $input
     ) {
         $this->nostoHelperAccount = $nostoHelperAccount;
         $this->nostoServiceIndex = $nostoServiceIndex;
         $this->productCollectionFactory = $productCollectionFactory;
+        $this->input = $input;
     }
 
     /**
@@ -160,6 +166,6 @@ class Invalidate implements IndexerActionInterface, MviewActionInterface
      */
     public function allowFullExecution()
     {
-        return IndexerUtil::isCalledFromSetupUpgrade() === false;
+        return IndexerUtil::isCalledFromSetupUpgrade($this->input) === false;
     }
 }

--- a/Util/Indexer.php
+++ b/Util/Indexer.php
@@ -36,21 +36,18 @@
 
 namespace Nosto\Tagging\Util;
 
+use Symfony\Component\Console\Input\InputInterface;
+
 class Indexer
 {
     /**
      * Checks if the execution scope is from Magento's setup:upgrade
      *
+     * @param InputInterface $input
      * @return bool
      */
-    public static function isCalledFromSetupUpgrade()
+    public static function isCalledFromSetupUpgrade(InputInterface $input)
     {
-        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 50);
-        foreach ($trace as $caller) {
-            if (!empty($caller['class']) && stristr($caller['class'], 'UpgradeCommand') !== false) {
-                return true;
-            }
-        }
-        return false;
+        return (bool)strstr($input->getFirstArgument(), 'setup:upgrade');
     }
 }

--- a/Util/Indexer.php
+++ b/Util/Indexer.php
@@ -40,6 +40,12 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class Indexer
 {
+    /** Non-ambiguous scope for settings commands */
+    const SETUP_UPGRADE_SCOPE = 'se';
+
+    /** Non-ambiguous action argument for settings command */
+    const SETUP_UPGRADE_ACTION = 'up';
+
     /**
      * Checks if the execution scope is from Magento's setup:upgrade
      *
@@ -48,6 +54,16 @@ class Indexer
      */
     public static function isCalledFromSetupUpgrade(InputInterface $input)
     {
-        return (bool)strstr($input->getFirstArgument(), 'setup:upgrade');
+        $parts = explode(':', $input->getFirstArgument());
+        if (count($parts) !== 2) {
+            return false;
+        }
+        list($commandScope, $commandAction) = $parts;
+        $currentCommandScope = substr($commandScope, 0, strlen(self::SETUP_UPGRADE_SCOPE));
+        $currentCommandAction = substr($commandAction, 0, strlen(self::SETUP_UPGRADE_ACTION));
+        return (
+            $currentCommandScope === self::SETUP_UPGRADE_SCOPE
+            && $currentCommandAction === self::SETUP_UPGRADE_ACTION
+        );
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -127,4 +127,9 @@
             <argument name="productServiceInterface" xsi:type="object">Nosto\Tagging\Model\Service\CachingProductService</argument>
         </arguments>
     </type>
+    <type name="Nosto\Tagging\Model\Indexer\Invalidate">
+        <arguments>
+            <argument name="input" xsi:type="object">Symfony\Component\Console\Input\ArgvInput</argument>
+        </arguments>
+    </type>
 </config>

--- a/phan.php
+++ b/phan.php
@@ -56,6 +56,7 @@ return [
         'vendor/monolog',
         'vendor/zendframework',
         'vendor/psr',
+        'vendor/symfony/console',
         'magento/generated',
         '../../../app/code/Magento/Store', // When Running Locally
         'magento/app/code/Magento/Store' // When Running on CI


### PR DESCRIPTION
## Description
Inject `InputInterface` and check the "caller" from arguments rather than going through the debug backtrace.

## Motivation and Context
Going through the backtrace was a bit hacky pattern. 

## How Has This Been Tested?
Tested locally with `setup:upgrade` and full reindex. 
corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
