### PR TITLE
Bugfixes - Incorrect product URL and product data not generated from CachingProductService

### DIFF
--- a/Model/Indexer/AbstractIndexer.php
+++ b/Model/Indexer/AbstractIndexer.php
@@ -56,6 +56,7 @@ use Traversable;
 use ArrayIterator;
 use InvalidArgumentException;
 use UnexpectedValueException;
+use Magento\Store\Model\App\Emulation;
 
 abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerActionInterface, MviewActionInterface
 {
@@ -74,6 +75,9 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
     /** @var DimensionProviderInterface */
     private $dimensionProvider;
 
+    /** @var Emulation */
+    private $storeEmulator;
+
     /**
      * AbstractIndexer constructor.
      * @param NostoHelperAccount $nostoHelperAccount
@@ -87,6 +91,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
         NostoHelperScope $nostoHelperScope,
         NostoLogger $nostoLogger,
         StoreDimensionProvider $dimensionProvider,
+        Emulation $storeEmulator,
         ProcessManager $processManager = null
     ) {
         $this->nostoHelperAccount = $nostoHelperAccount;
@@ -94,6 +99,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
         $this->nostoLogger = $nostoLogger;
         $this->dimensionProvider = $dimensionProvider;
         $this->processManager = $processManager;
+        $this->storeEmulator = $storeEmulator;
     }
 
     /**
@@ -180,6 +186,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
         }
 
         $storeId = $dimensions[StoreDimensionProvider::DIMENSION_NAME]->getValue();
+        $this->storeEmulator->startEnvironmentEmulation($storeId);
         $store = $this->nostoHelperScope->getStore($storeId);
         $benchmarkName = sprintf('STORE-DIMENSION-%s', $store->getCode());
         Benchmark::getInstance()->startInstrumentation($benchmarkName, 0);
@@ -196,6 +203,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
         $this->nostoLogger->info(
             '[END] NOSTO-DIMENSION store:' . $store->getName() . '(' . round($duration, 2) . ' secs)'
         );
+        $this->storeEmulator->stopEnvironmentEmulation();
     }
 
     /**

--- a/Model/Indexer/AbstractIndexer.php
+++ b/Model/Indexer/AbstractIndexer.php
@@ -186,7 +186,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
         }
 
         $storeId = $dimensions[StoreDimensionProvider::DIMENSION_NAME]->getValue();
-        $this->storeEmulator->startEnvironmentEmulation($storeId);
+        $this->storeEmulator->startEnvironmentEmulation((int)$storeId);
         $store = $this->nostoHelperScope->getStore($storeId);
         $benchmarkName = sprintf('STORE-DIMENSION-%s', $store->getCode());
         Benchmark::getInstance()->startInstrumentation($benchmarkName, 0);

--- a/Model/Indexer/Data.php
+++ b/Model/Indexer/Data.php
@@ -48,6 +48,7 @@ use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Magento\Indexer\Model\ProcessManager;
 use Magento\Store\Model\StoreDimensionProvider;
+use Magento\Store\Model\App\Emulation;
 
 /**
  * An indexer for Nosto product sync
@@ -79,6 +80,7 @@ class Data extends AbstractIndexer
         DataModeSwitcher $dataModeSwitcher,
         NostoLogger $logger,
         StoreDimensionProvider $dimensionProvider,
+        Emulation $storeEmulation,
         ProcessManager $processManager
     ) {
         $this->nostoServiceIndex = $nostoServiceIndex;
@@ -88,6 +90,7 @@ class Data extends AbstractIndexer
             $nostoHelperScope,
             $logger,
             $dimensionProvider,
+            $storeEmulation,
             $processManager
         );
     }

--- a/Model/Indexer/Invalidate.php
+++ b/Model/Indexer/Invalidate.php
@@ -51,6 +51,7 @@ use Magento\Indexer\Model\ProcessManager;
 use Nosto\Tagging\Model\Indexer\Dimensions\Invalidate\ModeSwitcher as InvalidateModeSwitcher;
 use Magento\Store\Model\StoreDimensionProvider;
 use Symfony\Component\Console\Input\InputInterface;
+use Magento\Store\Model\App\Emulation;
 
 /**
  * Class Invalidate
@@ -86,7 +87,9 @@ class Invalidate extends AbstractIndexer
      * @param ProductCollectionFactory $productCollectionFactory
      * @param InvalidateModeSwitcher $modeSwitcher
      * @param StoreDimensionProvider $dimensionProvider
+     * @param Emulation $storeEmulation
      * @param ProcessManager $processManager
+     * @param InputInterface $input
      */
     public function __construct(
         NostoHelperAccount $nostoHelperAccount,
@@ -96,6 +99,7 @@ class Invalidate extends AbstractIndexer
         ProductCollectionFactory $productCollectionFactory,
         InvalidateModeSwitcher $modeSwitcher,
         StoreDimensionProvider $dimensionProvider,
+        Emulation $storeEmulation,
         ProcessManager $processManager,
         InputInterface $input
     ) {
@@ -109,6 +113,7 @@ class Invalidate extends AbstractIndexer
             $nostoHelperScope,
             $logger,
             $dimensionProvider,
+            $storeEmulation,
             $processManager
         );
     }

--- a/Model/Service/CachingProductService.php
+++ b/Model/Service/CachingProductService.php
@@ -100,7 +100,7 @@ class CachingProductService implements ProductServiceInterface
             $indexedProduct = $this->nostoIndexRepository->getOneByProductAndStore($product, $store);
             //In case the product is not present in the index table
             if ($indexedProduct === null) {
-                $this->nostoIndexService->updateOrCreateDirtyEntity($fullProduct, $store);
+                $this->nostoIndexService->updateOrCreateDirtyEntity($product, $store);
                 $indexedProduct = $this->nostoIndexRepository->getOneByProductAndStore($product, $store);
             }
             //If it is dirty rebuild the product data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- When product data is dirty, then CachingProductService will call Model\Service\Index::rebuildDirtyProduct() to build the product data

- The store query param in the product URL is incorrect when data is generated from the indexer. Issue was caused because the Environment Emulation was not implemented in the new indexer. 

## Related Issue
closes #556 , #557

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
