### PR TITLE
Cleanup cl tables automatically

### DIFF
--- a/Model/Indexer/AbstractIndexer.php
+++ b/Model/Indexer/AbstractIndexer.php
@@ -44,8 +44,7 @@ use Magento\Framework\Indexer\Dimension;
 use Magento\Framework\Indexer\DimensionalIndexerInterface;
 use Magento\Framework\Indexer\DimensionProviderInterface;
 use Magento\Framework\Mview\ActionInterface as MviewActionInterface;
-use Magento\Framework\Mview\View;
-use Magento\Framework\Mview\ViewInterface;
+use Magento\Framework\Mview\View as Mview;
 use Magento\Indexer\Model\ProcessManager;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\Store;
@@ -80,7 +79,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
     /** @var Emulation */
     private $storeEmulator;
 
-    /** @var ViewInterface */
+    /** @var Mview */
     private $mview;
 
     /**
@@ -90,7 +89,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
      * @param NostoLogger $nostoLogger
      * @param StoreDimensionProvider $dimensionProvider
      * @param Emulation $storeEmulator
-     * @param View $mview
+     * @param Mview $mview
      * @param ProcessManager|null $processManager
      */
     public function __construct(
@@ -99,7 +98,7 @@ abstract class AbstractIndexer implements DimensionalIndexerInterface, IndexerAc
         NostoLogger $nostoLogger,
         StoreDimensionProvider $dimensionProvider,
         Emulation $storeEmulator,
-        View $mview,
+        Mview $mview,
         ProcessManager $processManager = null
     ) {
         $this->nostoHelperAccount = $nostoHelperAccount;

--- a/Model/Indexer/Data.php
+++ b/Model/Indexer/Data.php
@@ -37,7 +37,7 @@
 namespace Nosto\Tagging\Model\Indexer;
 
 use Exception;
-use Magento\Framework\Mview\View;
+use Magento\Framework\Mview\View as Mview;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
 use Nosto\Tagging\Model\Indexer\Dimensions\ModeSwitcherInterface;
@@ -74,7 +74,7 @@ class Data extends AbstractIndexer
      * @param StoreDimensionProvider $dimensionProvider
      * @param Emulation $storeEmulation
      * @param ProcessManager $processManager
-     * @param View $mview
+     * @param Mview $mview
      */
     public function __construct(
         NostoIndexService $nostoServiceIndex,
@@ -85,7 +85,7 @@ class Data extends AbstractIndexer
         StoreDimensionProvider $dimensionProvider,
         Emulation $storeEmulation,
         ProcessManager $processManager,
-        View $mview
+        Mview $mview
     ) {
         $this->nostoServiceIndex = $nostoServiceIndex;
         $this->modeSwitcher = $dataModeSwitcher;

--- a/Model/Indexer/Data.php
+++ b/Model/Indexer/Data.php
@@ -37,7 +37,7 @@
 namespace Nosto\Tagging\Model\Indexer;
 
 use Exception;
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Mview\View;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
 use Nosto\Tagging\Model\Indexer\Dimensions\ModeSwitcherInterface;
@@ -74,6 +74,7 @@ class Data extends AbstractIndexer
      * @param StoreDimensionProvider $dimensionProvider
      * @param Emulation $storeEmulation
      * @param ProcessManager $processManager
+     * @param View $mview
      */
     public function __construct(
         NostoIndexService $nostoServiceIndex,
@@ -83,7 +84,8 @@ class Data extends AbstractIndexer
         NostoLogger $logger,
         StoreDimensionProvider $dimensionProvider,
         Emulation $storeEmulation,
-        ProcessManager $processManager
+        ProcessManager $processManager,
+        View $mview
     ) {
         $this->nostoServiceIndex = $nostoServiceIndex;
         $this->modeSwitcher = $dataModeSwitcher;
@@ -93,6 +95,7 @@ class Data extends AbstractIndexer
             $logger,
             $dimensionProvider,
             $storeEmulation,
+            $mview,
             $processManager
         );
     }

--- a/Model/Indexer/Invalidate.php
+++ b/Model/Indexer/Invalidate.php
@@ -37,7 +37,7 @@
 namespace Nosto\Tagging\Model\Indexer;
 
 use Exception;
-use Magento\Framework\Mview\View;
+use Magento\Framework\Mview\View as Mview;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
@@ -91,7 +91,7 @@ class Invalidate extends AbstractIndexer
      * @param Emulation $storeEmulation
      * @param ProcessManager $processManager
      * @param InputInterface $input
-     * @param View $mview
+     * @param Mview $mview
      */
     public function __construct(
         NostoHelperAccount $nostoHelperAccount,
@@ -104,7 +104,7 @@ class Invalidate extends AbstractIndexer
         Emulation $storeEmulation,
         ProcessManager $processManager,
         InputInterface $input,
-        View $mview
+        Mview $mview
     ) {
         $this->nostoServiceIndex = $nostoServiceIndex;
         $this->nostoHelperAccount = $nostoHelperAccount;

--- a/Model/Indexer/Invalidate.php
+++ b/Model/Indexer/Invalidate.php
@@ -37,6 +37,7 @@
 namespace Nosto\Tagging\Model\Indexer;
 
 use Exception;
+use Magento\Framework\Mview\View;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
@@ -90,6 +91,7 @@ class Invalidate extends AbstractIndexer
      * @param Emulation $storeEmulation
      * @param ProcessManager $processManager
      * @param InputInterface $input
+     * @param View $mview
      */
     public function __construct(
         NostoHelperAccount $nostoHelperAccount,
@@ -101,7 +103,8 @@ class Invalidate extends AbstractIndexer
         StoreDimensionProvider $dimensionProvider,
         Emulation $storeEmulation,
         ProcessManager $processManager,
-        InputInterface $input
+        InputInterface $input,
+        View $mview
     ) {
         $this->nostoServiceIndex = $nostoServiceIndex;
         $this->nostoHelperAccount = $nostoHelperAccount;
@@ -114,6 +117,7 @@ class Invalidate extends AbstractIndexer
             $logger,
             $dimensionProvider,
             $storeEmulation,
+            $mview,
             $processManager
         );
     }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -43,7 +43,6 @@
     <preference for="Nosto\Tagging\Util\Serializer\SerializerInterface" type="Nosto\Tagging\Util\Serializer\DefaultSerializer"/>
     <preference for="Nosto\Tagging\Model\Service\Comparator\ProductComparatorInterface" type="Nosto\Tagging\Model\Service\Comparator\DefaultProductComparator"/>
     <preference for="Nosto\Tagging\Model\Service\Sync\BulkSyncInterface" type="Nosto\Tagging\Model\Service\Sync\AsyncBulkPublisher"/>
-    <preference for="Magento\Framework\Mview\View\ChangelogInterface" type="Magento\Framework\Mview\View\Changelog"/>
     <type name="Magento\Catalog\Model\ResourceModel\Product">
         <plugin name="nostoProductObserverInvalidate" type="Nosto\Tagging\Plugin\ProductInvalidate"/>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -43,6 +43,7 @@
     <preference for="Nosto\Tagging\Util\Serializer\SerializerInterface" type="Nosto\Tagging\Util\Serializer\DefaultSerializer"/>
     <preference for="Nosto\Tagging\Model\Service\Comparator\ProductComparatorInterface" type="Nosto\Tagging\Model\Service\Comparator\DefaultProductComparator"/>
     <preference for="Nosto\Tagging\Model\Service\Sync\BulkSyncInterface" type="Nosto\Tagging\Model\Service\Sync\AsyncBulkPublisher"/>
+    <preference for="Magento\Framework\Mview\View\ChangelogInterface" type="Magento\Framework\Mview\View\Changelog"/>
     <type name="Magento\Catalog\Model\ResourceModel\Product">
         <plugin name="nostoProductObserverInvalidate" type="Nosto\Tagging\Plugin\ProductInvalidate"/>
     </type>


### PR DESCRIPTION
## Description
Add a logic for cleaning up the CL tables after indexer run. 

## Motivation and Context
Due to the big amount of subscriptions the CL tables (especially for the invalidate indexer) tend to grow big when making a lot product updates. 

## How Has This Been Tested?
Tested locally by running the full reindex and letting the cron to to handle the indexing. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
