### PR TITLE
Prevent full reindex on setup upgrade for both indexers

### DIFF
--- a/Model/Indexer/Data.php
+++ b/Model/Indexer/Data.php
@@ -50,6 +50,7 @@ use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Magento\Indexer\Model\ProcessManager;
 use Nosto\Tagging\Model\Indexer\Dimensions\StoreDimensionProvider;
 use Magento\Store\Model\App\Emulation;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * An indexer for Nosto product sync
@@ -83,7 +84,8 @@ class Data extends AbstractIndexer
         NostoLogger $logger,
         StoreDimensionProvider $dimensionProvider,
         Emulation $storeEmulation,
-        ProcessManager $processManager
+        ProcessManager $processManager,
+        InputInterface $input
     ) {
         $this->nostoServiceIndex = $nostoServiceIndex;
         $this->modeSwitcher = $dataModeSwitcher;
@@ -93,44 +95,9 @@ class Data extends AbstractIndexer
             $logger,
             $dimensionProvider,
             $storeEmulation,
+            $input,
             $processManager
         );
-    }
-
-    /**
-     * @inheritdoc
-     * @throws Exception
-     */
-    public function executeFull()
-    {
-        $this->doWork();
-    }
-
-    /**
-     * @inheritdoc
-     * @throws Exception
-     */
-    public function executeList(array $ids)
-    {
-        $this->execute($ids);
-    }
-
-    /**
-     * @inheritdoc
-     * @throws Exception
-     */
-    public function executeRow($id)
-    {
-        $this->execute([$id]);
-    }
-
-    /**
-     * @inheritdoc
-     * @throws Exception
-     */
-    public function execute($ids)
-    {
-        $this->doWork($ids);
     }
 
     /**

--- a/Model/Indexer/Invalidate.php
+++ b/Model/Indexer/Invalidate.php
@@ -45,7 +45,6 @@ use Nosto\Tagging\Model\Indexer\Dimensions\ModeSwitcherInterface;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionFactory as ProductCollectionFactory;
 use Nosto\Tagging\Model\Service\Index as NostoServiceIndex;
-use Nosto\Tagging\Util\Indexer as IndexerUtil;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Magento\Indexer\Model\ProcessManager;
 use Nosto\Tagging\Model\Indexer\Dimensions\Invalidate\ModeSwitcher as InvalidateModeSwitcher;
@@ -74,9 +73,6 @@ class Invalidate extends AbstractIndexer
 
     /** @var InvalidateModeSwitcher */
     private $modeSwitcher;
-
-    /** @var InputInterface */
-    private $input;
 
     /**
      * Invalidate constructor.
@@ -107,53 +103,15 @@ class Invalidate extends AbstractIndexer
         $this->nostoHelperAccount = $nostoHelperAccount;
         $this->productCollectionFactory = $productCollectionFactory;
         $this->modeSwitcher = $modeSwitcher;
-        $this->input = $input;
         parent::__construct(
             $nostoHelperAccount,
             $nostoHelperScope,
             $logger,
             $dimensionProvider,
             $storeEmulation,
+            $input,
             $processManager
         );
-    }
-
-    /**
-     * @param int[] $ids
-     * @throws Exception
-     */
-    public function execute($ids)
-    {
-        $this->doWork($ids);
-    }
-
-    /**
-     * @inheritDoc
-     * @throws NostoException
-     */
-    public function executeFull()
-    {
-        if ($this->allowFullExecution() === true) {
-            $this->doWork();
-        }
-    }
-
-    /**
-     * @inheritDoc
-     * @throws Exception
-     */
-    public function executeList(array $ids)
-    {
-        $this->execute($ids);
-    }
-
-    /**
-     * @inheritDoc
-     * @throws Exception
-     */
-    public function executeRow($id)
-    {
-        $this->execute([$id]);
     }
 
     /**
@@ -212,13 +170,5 @@ class Invalidate extends AbstractIndexer
             $collection->addActiveAndVisibleFilter();
         }
         return $collection;
-    }
-
-    /**
-     * @return bool
-     */
-    public function allowFullExecution()
-    {
-        return IndexerUtil::isCalledFromSetupUpgrade($this->input) === false;
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -43,6 +43,7 @@
     <preference for="Nosto\Tagging\Util\Serializer\SerializerInterface" type="Nosto\Tagging\Util\Serializer\DefaultSerializer"/>
     <preference for="Nosto\Tagging\Model\Service\Comparator\ProductComparatorInterface" type="Nosto\Tagging\Model\Service\Comparator\DefaultProductComparator"/>
     <preference for="Nosto\Tagging\Model\Service\Sync\BulkSyncInterface" type="Nosto\Tagging\Model\Service\Sync\AsyncBulkPublisher"/>
+    <preference for="Symfony\Component\Console\Input\InputInterface" type="Symfony\Component\Console\Input\ArgvInput\Proxy"/>
     <type name="Magento\Catalog\Model\ResourceModel\Product">
         <plugin name="nostoProductObserverInvalidate" type="Nosto\Tagging\Plugin\ProductInvalidate"/>
     </type>
@@ -163,7 +164,6 @@
             <argument name="dimensionProvider" xsi:type="object" shared="false">
                 Nosto\Tagging\Model\Indexer\Dimensions\StoreDimensionProvider
             </argument>
-            <argument name="input" xsi:type="object">Symfony\Component\Console\Input\ArgvInput\Proxy</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
## Description
Move setup upgrade check and other common methods to the abstract indexer.

## Motivation and Context
There's no need to run the full data reindex either during the setup upgrade. This also fixes the emulation error. 

## How Has This Been Tested?
Tested locally by running the setup upgrade and full reindex via `indexer:reindex` command for both indexers. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
