### PR TITLE
Bug - fix case of bundle products without options

### DIFF
--- a/Model/Service/Index.php
+++ b/Model/Service/Index.php
@@ -257,7 +257,7 @@ class Index extends AbstractService
      */
     public function updateOrCreateDirtyEntity(ProductInterface $product, StoreInterface $store)
     {
-        if (!$this->canNostoBuildProduct($product)) {
+        if (!$this->canBuildBundleProduct($product)) {
             $this->getLogger()
                 ->debug(sprintf('Product %s cannot be processed by Nosto', $product->getId()));
             return;
@@ -282,7 +282,7 @@ class Index extends AbstractService
      * @param ProductInterface $product
      * @return bool
      */
-    private function canNostoBuildProduct(ProductInterface $product)
+    private function canBuildBundleProduct(ProductInterface $product)
     {
         if ($product->getTypeId() === Type::TYPE_BUNDLE && empty($product->getOptions())) {
             return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a product bundle without option is indexed, it will be added in the indexing table and fail building the price as it has no options.

## Related Issue
closes #566

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
