### PR TITLE
Handle indexed products without data and not marked as dirty

### DIFF
--- a/Api/Data/ProductIndexInterface.php
+++ b/Api/Data/ProductIndexInterface.php
@@ -111,7 +111,7 @@ interface ProductIndexInterface
     /**
      * Get product data
      *
-     * @return string
+     * @return string|null
      */
     public function getProductData();
 

--- a/Model/Product/Index/Index.php
+++ b/Model/Product/Index/Index.php
@@ -93,7 +93,11 @@ class Index extends AbstractModel implements ProductIndexInterface
      */
     public function getProductData()
     {
-        return $this->getData(self::PRODUCT_DATA);
+        $productData = $this->getData(self::PRODUCT_DATA);
+        if (empty($productData)) {
+            return null;
+        }
+        return $productData;
     }
 
     /**

--- a/Model/Service/Sync/SyncService.php
+++ b/Model/Service/Sync/SyncService.php
@@ -139,13 +139,23 @@ class SyncService extends AbstractService
             $op->setResponseTimeout(self::RESPONSE_TIMEOUT);
             /** @var ProductIndexInterface $productIndex */
             foreach ($page as $productIndex) {
+                $productData = $productIndex->getProductData();
+                if (empty($productData) && !$productIndex->getIsDirty()) {
+                    throw new NostoException(
+                        'Something is wrong in the nosto product index table.
+                        Product do not have data nor is marked as dirty'
+                    );
+                }
+                if (empty($productData)) {
+                    continue; // Do not sync products with null data
+                }
                 $this->getLogger()->debug(
                     sprintf('Upserting product "%s"', $productIndex->getProductId()),
                     ['store' => $productIndex->getStoreId()]
                 );
                 $op->addProduct(
                     $this->productSerializer->fromString(
-                        $productIndex->getProductData()
+                        $productData
                     )
                 );
             }


### PR DESCRIPTION
## Description
Avoid crashing when the indexed product has no data.

## Related Issue
Fixes #573
## Motivation and Context
N/A
## How Has This Been Tested?
Locally clearing product data directly on DB, running data indexer, and consuming queues;

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
