### PR TITLE
Remove white space and line breaks before product comparison

### DIFF
--- a/Util/StringUtil.php
+++ b/Util/StringUtil.php
@@ -34,23 +34,26 @@
  *
  */
 
-namespace Nosto\Tagging\Model\Service\Product;
+namespace Nosto\Tagging\Util;
 
-use Nosto\Helper\SerializationHelper;
-use Nosto\Tagging\Model\Service\Product\ComparatorInterface;
-use Nosto\Tagging\Util\StringUtil;
-use Nosto\Types\Product\ProductInterface;
-
-class DefaultComparator implements ComparatorInterface
+class StringUtil
 {
     /**
-     * @inheritDoc
+     * Strips out all whitespace and line breaks from a given string
+     *
+     * @param string $string
+     * @return string
      */
-    public function isEqual(ProductInterface $product1, ProductInterface $product2)
+    public static function stripWhitespaceAndLinebreaks($string)
     {
-        $product1string = StringUtil::stripWhitespaceAndLinebreaks(SerializationHelper::serialize($product1));
-        $product2string = StringUtil::stripWhitespaceAndLinebreaks(SerializationHelper::serialize($product2));
-
-        return $product1string === $product2string;
+        return preg_replace(
+            '/[ \t]+/',
+            ' ',
+            preg_replace(
+                '/[\r\n]+/',
+                "\n",
+                $string
+            )
+        );
     }
 }


### PR DESCRIPTION
## Description
Strip out all white space & line breaks before comparing two product objects. 

## Motivation and Context
Product data contains redundant line breaks and white space when saving product data in store admin.

## How Has This Been Tested?
Tested locally by running the indexer from command line and saving products in store admin.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
