### PR TITLE
Consolidate collection usage & introduce collection builder 

### DIFF
--- a/Block/Product.php
+++ b/Block/Product.php
@@ -37,7 +37,6 @@
 namespace Nosto\Tagging\Block;
 
 use Exception;
-use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Block\Product\Context;
 use Magento\Catalog\Block\Product\View;
@@ -50,6 +49,7 @@ use Magento\Framework\Stdlib\StringUtils;
 use Magento\Framework\Url\EncoderInterface as UrlEncoder;
 use Nosto\Helper\DateHelper;
 use Nosto\Helper\PriceHelper;
+use Nosto\Object\Product\Product as NostoProduct;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Model\Category\Builder as NostoCategoryBuilder;
@@ -131,7 +131,7 @@ class Product extends View
     /**
      * Returns the Nosto product DTO.
      *
-     * @return ProductInterface
+     * @return NostoProduct
      * @throws Exception
      */
     public function getAbstractObject()

--- a/Controller/Export/Product.php
+++ b/Controller/Export/Product.php
@@ -39,13 +39,14 @@ namespace Nosto\Tagging\Controller\Export;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\Result\Raw as RawResult;
 use Magento\Store\Model\Store;
+use Nosto\Helper\SerializationHelper;
 use Nosto\NostoException;
 use Nosto\Object\AbstractCollection;
 use Nosto\Object\Product\Product as NostoProduct;
 use Nosto\Object\Product\ProductCollection;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
-use Nosto\Tagging\Model\Product\Collection as NostoProductCollection;
+use Nosto\Tagging\Model\Product\CollectionBuilder;
 use Nosto\Tagging\Model\Service\Sync\SyncService as NostoSyncService;
 
 /**
@@ -59,8 +60,8 @@ class Product extends Base
 {
     const PARAM_PREVIEW = 'preview';
 
-    /** @var NostoProductCollection */
-    private $nostoProductCollection;
+    /** @var CollectionBuilder  */
+    private $nostoCollectionBuilder;
 
     /** @var NostoSyncService */
     private $nostoSyncService;
@@ -71,19 +72,19 @@ class Product extends Base
      * @param Context $context
      * @param NostoHelperScope $nostoHelperScope
      * @param NostoHelperAccount $nostoHelperAccount
-     * @param NostoProductCollection $nostoProductCollection
+     * @param CollectionBuilder $collectionBuilder
      * @param NostoSyncService $nostoSyncService
      */
     public function __construct(
         Context $context,
         NostoHelperScope $nostoHelperScope,
         NostoHelperAccount $nostoHelperAccount,
-        NostoProductCollection $nostoProductCollection,
+        CollectionBuilder $collectionBuilder,
         NostoSyncService $nostoSyncService
     ) {
         parent::__construct($context, $nostoHelperScope, $nostoHelperAccount);
 
-        $this->nostoProductCollection = $nostoProductCollection;
+        $this->nostoCollectionBuilder = $collectionBuilder;
         $this->nostoSyncService = $nostoSyncService;
     }
 
@@ -96,7 +97,7 @@ class Product extends Base
      */
     public function buildExportCollection(Store $store, $limit = 100, $offset = 0)
     {
-        return $this->nostoProductCollection->buildMany($store, $limit, $offset);
+        return $this->nostoCollectionBuilder->buildMany($store, $limit, $offset);
     }
 
     /**
@@ -107,7 +108,7 @@ class Product extends Base
      */
     public function buildSingleExportCollection(Store $store, $id)
     {
-        return $this->nostoProductCollection->buildSingle($store, $id);
+        return $this->nostoCollectionBuilder->buildSingle($store, $id);
     }
 
     /**

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN        service mysql start && \
            cd /var/www/html && \
            composer config --global repositories.0 composer https://repo.magento.com && \
            composer config --global http-basic.repo.magento.com $repouser $repopass && \
-           composer create-project magento/community-edition && \
+           composer create-project magento/community-edition=2.3.2 && \
            cd community-edition && \
            composer update && \
            composer config --unset minimum-stability && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
 
     stage('Phan Analysis') {
       steps {
-        sh "composer create-project magento/community-edition magento"
+        sh "composer create-project magento/community-edition=2.3.2 magento"
         sh "cd magento && composer config minimum-stability dev"
         sh "cd magento && composer config prefer-stable true"
         script {

--- a/Model/Indexer/Invalidate.php
+++ b/Model/Indexer/Invalidate.php
@@ -46,6 +46,7 @@ use Nosto\Tagging\Model\Indexer\Dimensions\Invalidate\ModeSwitcher as Invalidate
 use Nosto\Tagging\Model\Indexer\Dimensions\ModeSwitcherInterface;
 use Nosto\Tagging\Model\Indexer\Dimensions\StoreDimensionProvider;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionFactory as ProductCollectionFactory;
 use Nosto\Tagging\Model\Service\Cache\CacheService;
 use Nosto\Tagging\Model\Service\Indexer\IndexerStatusServiceInterface;
@@ -64,8 +65,8 @@ class Invalidate extends AbstractIndexer
     /** @var CacheService */
     private $nostoServiceIndex;
 
-    /** @var ProductCollectionFactory */
-    private $productCollectionFactory;
+    /** @var CollectionBuilder */
+    private $productCollectionBuilder;
 
     /** @var InvalidateModeSwitcher */
     private $modeSwitcher;
@@ -75,7 +76,7 @@ class Invalidate extends AbstractIndexer
      * @param NostoHelperScope $nostoHelperScope
      * @param CacheService $nostoCacheService
      * @param NostoLogger $logger
-     * @param ProductCollectionFactory $productCollectionFactory
+     * @param ProductCollectionFactory $productCollectionBuilder
      * @param InvalidateModeSwitcher $modeSwitcher
      * @param StoreDimensionProvider $dimensionProvider
      * @param Emulation $storeEmulation
@@ -87,7 +88,7 @@ class Invalidate extends AbstractIndexer
         NostoHelperScope $nostoHelperScope,
         CacheService $nostoCacheService,
         NostoLogger $logger,
-        ProductCollectionFactory $productCollectionFactory,
+        CollectionBuilder $productCollectionBuilder,
         InvalidateModeSwitcher $modeSwitcher,
         StoreDimensionProvider $dimensionProvider,
         Emulation $storeEmulation,
@@ -96,7 +97,7 @@ class Invalidate extends AbstractIndexer
         IndexerStatusServiceInterface $indexerStatusService
     ) {
         $this->nostoServiceIndex = $nostoCacheService;
-        $this->productCollectionFactory = $productCollectionFactory;
+        $this->productCollectionBuilder = $productCollectionBuilder;
         $this->modeSwitcher = $modeSwitcher;
         parent::__construct(
             $nostoHelperScope,
@@ -125,7 +126,6 @@ class Invalidate extends AbstractIndexer
     {
         $productCollection = $this->getCollection($store, $ids);
         $this->nostoServiceIndex->invalidateOrCreate($productCollection, $store);
-
         if (!empty($ids)) {
             //In case for this specific set of ids
             //there are more entries of products in the indexer table than the magento product collection
@@ -154,13 +154,12 @@ class Invalidate extends AbstractIndexer
      */
     public function getCollection(Store $store, array $ids = [])
     {
-        $collection = $this->productCollectionFactory->create();
-        $collection->setStore($store);
+        $this->productCollectionBuilder->initDefault($store);
         if (!empty($ids)) {
-            $collection->addIdsToFilter($ids);
+            $this->productCollectionBuilder->withIds($ids);
         } else {
-            $collection->addActiveAndVisibleFilter();
+            $this->productCollectionBuilder->withDefaultVisibility();
         }
-        return $collection;
+        return $this->productCollectionBuilder->build();
     }
 }

--- a/Model/Product/CollectionBuilder.php
+++ b/Model/Product/CollectionBuilder.php
@@ -38,6 +38,7 @@ namespace Nosto\Tagging\Model\Product;
 
 use Exception;
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
 use Nosto\Object\Product\ProductCollection as NostoProductCollection;
@@ -116,14 +117,14 @@ class CollectionBuilder
     {
         /** @var ProductCollection $collection */
         $products = new NostoProductCollection();
-        $items = $collection->getItems();
+        $items = $collection->load();
         if ($items instanceof Traversable === false && !is_array($items)) {
             throw new NostoException(
                 sprintf('Invalid collection type %s for product export', get_class($collection))
             );
         }
         foreach ($items as $product) {
-            /** @var ProductInterface $product */
+            /** @var Product $product */
             try {
                 $nostoProduct = $this->productServiceInterface->getProduct(
                     $product,

--- a/Model/Product/CollectionBuilder.php
+++ b/Model/Product/CollectionBuilder.php
@@ -47,10 +47,18 @@ use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder as Produ
 use Nosto\Tagging\Model\Service\Product\ProductServiceInterface;
 use Traversable;
 
+/**
+ * A builder class for building collection containing Nosto products
+ */
 class CollectionBuilder
 {
+    /** @var ProductCollectionBuilder */
     private $productCollectionBuilder;
+
+    /** @var ProductServiceInterface */
     private $productServiceInterface;
+
+    /** @var NostoLogger */
     private $logger;
 
     /**

--- a/Model/Product/CollectionBuilder.php
+++ b/Model/Product/CollectionBuilder.php
@@ -122,8 +122,8 @@ class CollectionBuilder
                 sprintf('Invalid collection type %s for product export', get_class($collection))
             );
         }
-        /** @var Product $product */
         foreach ($items as $product) {
+            /** @var Product $product */
             try {
                 $nostoProduct = $this->productServiceInterface->getProduct(
                     $product,

--- a/Model/Product/CollectionBuilder.php
+++ b/Model/Product/CollectionBuilder.php
@@ -37,7 +37,7 @@
 namespace Nosto\Tagging\Model\Product;
 
 use Exception;
-use Magento\Catalog\Model\Product;
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
 use Nosto\Object\Product\ProductCollection as NostoProductCollection;
@@ -123,7 +123,7 @@ class CollectionBuilder
             );
         }
         foreach ($items as $product) {
-            /** @var Product $product */
+            /** @var ProductInterface $product */
             try {
                 $nostoProduct = $this->productServiceInterface->getProduct(
                     $product,

--- a/Model/ResourceModel/Magento/Product/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Product/CollectionBuilder.php
@@ -65,7 +65,6 @@ class CollectionBuilder
         ProductCollectionFactory $productCollectionFactory,
         ProductVisibility $productVisibility
     ) {
-        $this->collection = $productCollectionFactory->create();
         $this->productCollectionFactory = $productCollectionFactory;
         $this->productVisibility = $productVisibility;
     }
@@ -190,9 +189,20 @@ class CollectionBuilder
      */
     public function reset()
     {
+        return $this->init();
+    }
+
+    /**
+     * Initializes the collection
+     *
+     * @return $this
+     */
+    public function init()
+    {
         $this->collection = $this->productCollectionFactory->create();
         return $this;
     }
+
     /**
      * Initializes the collection with store filter and defaults
      *

--- a/Model/ResourceModel/Magento/Product/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Product/CollectionBuilder.php
@@ -71,7 +71,6 @@ class CollectionBuilder
         $this->collection = $productCollectionFactory->create();
         $this->productCollectionFactory = $productCollectionFactory;
         $this->productVisibility = $productVisibility;
-
     }
 
     /**

--- a/Model/ResourceModel/Magento/Product/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Product/CollectionBuilder.php
@@ -47,13 +47,10 @@ use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionFactory as Produ
  */
 class CollectionBuilder
 {
-    /**
-     * @var ProductVisibility
-     */
+    /** @var ProductVisibility */
     private $productVisibility;
-    /**
-     * @var Collection
-     */
+
+    /** @var Collection */
     private $collection;
 
     /** @var CollectionFactory */

--- a/Model/ResourceModel/Magento/Product/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Product/CollectionBuilder.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\ResourceModel\Magento\Product;
+
+use Magento\Catalog\Model\Product\Visibility as ProductVisibility;
+use Magento\Sales\Api\Data\EntityInterface;
+use Magento\Store\Model\Store;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionFactory as ProductCollectionFactory;
+
+/**
+ * A builder class for building product collection with the most common filters
+ */
+class CollectionBuilder
+{
+    /**
+     * @var ProductVisibility
+     */
+    private $productVisibility;
+    /**
+     * @var Collection
+     */
+    private $collection;
+
+    /** @var CollectionFactory */
+    private $productCollectionFactory;
+
+    /**
+     * Collection constructor.
+     * @param ProductCollectionFactory $productCollectionFactory
+     * @param ProductVisibility $productVisibility
+     */
+    public function __construct(
+        ProductCollectionFactory $productCollectionFactory,
+        ProductVisibility $productVisibility
+    ) {
+        $this->collection = $productCollectionFactory->create();
+        $this->productCollectionFactory = $productCollectionFactory;
+        $this->productVisibility = $productVisibility;
+
+    }
+
+    /**
+     * @return Collection
+     */
+    public function build()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * Sets filter for only products that are visible in active sites defined
+     * by store
+     * @return $this
+     */
+    public function withOnlyVisibleInSites()
+    {
+        $this->collection->setVisibility($this->productVisibility->getVisibleInSiteIds());
+        return $this;
+    }
+
+    /**
+     * Sets filter for only active products and globally visible products
+     *
+     * @return $this
+     */
+    public function withOnlyActiveAndVisible()
+    {
+        $this->collection->addActiveAndVisibleFilter();
+        return $this;
+    }
+
+    /**
+     * Sets the store filter
+     *
+     * @param Store $store
+     * @return $this
+     */
+    public function withStore(Store $store)
+    {
+        $this->collection->addStoreFilter($store);
+        $this->collection->setStore($store);
+        return $this;
+    }
+
+    /**
+     * Defines all attributes to be included into the collection items
+     *
+     * @return $this
+     */
+    public function withAllAttributes()
+    {
+        $this->collection->addAttributeToSelect('*');
+        return $this;
+    }
+
+    /**
+     * Sets filter for only given product ids
+     *
+     * @param array $ids
+     * @return $this
+     */
+    public function withIds(array $ids)
+    {
+        $this->collection->addIdsToFilter($ids);
+        return $this;
+    }
+
+    /**
+     * Sets the sort for the collection
+     *
+     * @param string $field
+     * @param string $sortOrder
+     * @return $this
+     */
+    public function setSort($field, $sortOrder)
+    {
+        $this->collection->setOrder($field, $sortOrder);
+        return $this;
+    }
+
+    /**
+     * Sets the page size
+     *
+     * @param $pageSize
+     * @return $this
+     */
+    public function setPageSize($pageSize)
+    {
+        $this->collection->setPageSize($pageSize);
+        return $this;
+    }
+
+    /**
+     * Sets the current page
+     *
+     * @param $currentPage
+     * @return $this
+     */
+    public function setCurrentPage($currentPage)
+    {
+        $this->collection->setCurPage($currentPage);
+        return $this;
+    }
+
+    /**
+     * Sets the default visibility. Calls self::withOnlyVisibleInSites()
+     * and self::withOnlyActiveAndVisible()
+     *
+     * @return CollectionBuilder
+     */
+    public function withDefaultVisibility()
+    {
+        return $this->withOnlyVisibleInSites()->withOnlyActiveAndVisible();
+    }
+
+    /**
+     * Resets the data and filters in collection
+     * @return $this
+     */
+    public function reset()
+    {
+        $this->collection = $this->productCollectionFactory->create();
+        return $this;
+    }
+    /**
+     * Initializes the collection with store filter and defaults
+     *
+     * @param Store $store
+     * @return CollectionBuilder
+     */
+    public function initDefault(Store $store)
+    {
+        /** @var ProductCollection $collection */
+        return $this
+            ->reset()
+            ->withStore($store)
+            ->withAllAttributes()
+            ->setSort(EntityInterface::CREATED_AT, $this->collection::SORT_ORDER_DESC);
+    }
+
+    /**
+     * Builds and returns the collection with single item (if found)
+     *
+     * @param Store $store
+     * @param $id
+     * @return Collection
+     */
+    public function buildSingle(Store $store, $id)
+    {
+        return $this
+            ->initDefault($store)
+            ->withIds([$id])
+            ->withDefaultVisibility()
+            ->build();
+    }
+
+    /**
+     * Builds collection with default visibility filter and given limit
+     * and offset.
+     *
+     * @param Store $store
+     * @param int $limit
+     * @param int $offset
+     * @return Collection
+     */
+    public function buildMany(Store $store, $limit = 100, $offset = 0)
+    {
+        $currentPage = ($offset / $limit) + 1;
+        return $this
+            ->initDefault($store)
+            ->withDefaultVisibility()
+            ->setPageSize($limit)
+            ->setCurrentPage($currentPage)
+            ->build();
+    }
+}

--- a/Model/Service/Product/ProductServiceInterface.php
+++ b/Model/Service/Product/ProductServiceInterface.php
@@ -36,15 +36,15 @@
 namespace Nosto\Tagging\Model\Service\Product;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
 use Magento\Store\Api\Data\StoreInterface;
-use Nosto\Object\Product\Product as NostoProduct;
 
 interface ProductServiceInterface
 {
     /**
      * @param ProductInterface $product
      * @param StoreInterface $store
-     * @return ProductInterface|NostoProduct|null
+     * @return ProductInterface|Product|null
      */
     public function getProduct(ProductInterface $product, StoreInterface $store);
 }

--- a/Model/Service/Product/ProductServiceInterface.php
+++ b/Model/Service/Product/ProductServiceInterface.php
@@ -36,15 +36,16 @@
 namespace Nosto\Tagging\Model\Service\Product;
 
 use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Model\Product;
 use Magento\Store\Api\Data\StoreInterface;
+use Nosto\Object\Product\Product as NostoProduct;
+use Nosto\Types\Product\ProductInterface as NostoProductInterface;
 
 interface ProductServiceInterface
 {
     /**
      * @param ProductInterface $product
      * @param StoreInterface $store
-     * @return ProductInterface|Product|null
+     * @return NostoProduct|NostoProductInterface|null
      */
     public function getProduct(ProductInterface $product, StoreInterface $store);
 }

--- a/Model/Service/Product/ProductServiceInterface.php
+++ b/Model/Service/Product/ProductServiceInterface.php
@@ -45,7 +45,7 @@ interface ProductServiceInterface
     /**
      * @param ProductInterface $product
      * @param StoreInterface $store
-     * @return NostoProduct|NostoProductInterface|null
+     * @return NostoProduct|null
      */
     public function getProduct(ProductInterface $product, StoreInterface $store);
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -146,7 +146,7 @@
             </argument>
         </arguments>
     </type>
-    <type name="Nosto\Tagging\Model\Product\Collection">
+    <type name="Nosto\Tagging\Model\Product\CollectionBuilder">
         <arguments>
             <argument name="productServiceInterface" xsi:type="object">
                 Nosto\Tagging\Model\Service\Product\CachingProductService


### PR DESCRIPTION
## Description
Introduce collection builder for building Magento product collection and use the same builder in export and indexing. 

## Motivation and Context
Indexer collection didn't limit the products correctly based on store visibility. Indexer collection was initialized with different filters than export collection.  

## How Has This Been Tested?
Tested locally by running the indexers and calling the export controllers.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
