### PR TITLE
Feature- Add mem check to indexers

### DIFF
--- a/Model/Indexer/Data.php
+++ b/Model/Indexer/Data.php
@@ -36,9 +36,11 @@
 
 namespace Nosto\Tagging\Model\Indexer;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Indexer\Model\ProcessManager;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\Store;
+use Nosto\Exception\MemoryOutOfBoundsException;
 use Nosto\NostoException;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
@@ -121,7 +123,11 @@ class Data extends AbstractIndexer
     {
         try {
             $this->nostoCacheService->generateProductsInStore($store, $ids);
+        } catch (MemoryOutOfBoundsException $e) {
+            $this->nostoLogger->error($e->getMessage());
         } catch (NostoException $e) {
+            $this->nostoLogger->error($e->getMessage());
+        } catch (LocalizedException $e) {
             $this->nostoLogger->error($e->getMessage());
         }
     }

--- a/Model/Service/Cache/CacheService.php
+++ b/Model/Service/Cache/CacheService.php
@@ -41,6 +41,7 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type;
 use Magento\Catalog\Model\ProductRepository;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Store\Api\Data\StoreInterface;
@@ -323,6 +324,7 @@ class CacheService extends AbstractService
      * @param array $ids
      * @throws NostoException
      * @throws MemoryOutOfBoundsException
+     * @throws LocalizedException
      */
     public function generateProductsInStore(Store $store, array $ids = [])
     {

--- a/Model/Service/Cache/CacheService.php
+++ b/Model/Service/Cache/CacheService.php
@@ -188,6 +188,7 @@ class CacheService extends AbstractService
      * @param ProductCollection $collection
      * @param Store $store
      * @throws NostoException
+     * @throws MemoryOutOfBoundsException
      * @throws Exception
      */
     public function invalidateOrCreate(ProductCollection $collection, Store $store)
@@ -201,6 +202,7 @@ class CacheService extends AbstractService
 
         /** @var ProductCollection $page */
         foreach ($iterator as $page) {
+            $this->checkMemoryConsumption('product invalidate');
             /** @var Product $item */
             foreach ($page->getItems() as $item) {
                 $this->invalidateOrCreateProductOrParent($item, $store);
@@ -436,6 +438,7 @@ class CacheService extends AbstractService
      * @param ProductCollection $collection
      * @param array $ids
      * @param Store $store
+     * @throws MemoryOutOfBoundsException
      * @throws Exception
      */
     public function markProductsAsDeletedByDiff(ProductCollection $collection, array $ids, Store $store)
@@ -447,6 +450,7 @@ class CacheService extends AbstractService
         /** @var ProductCollection $page */
         foreach ($iterator as $page) {
             /** @var Product $product */
+            $this->checkMemoryConsumption('mark product as deleted');
             foreach ($page->getItems() as $product) {
                 $key = array_search($product->getId(), $uniqueIds, false);
                 if (is_numeric($key)) {


### PR DESCRIPTION
## Description
Restore check for memory consumption, ending the indexer gracefully while logging an exception

## Related Issue
N/A

## Motivation and Context
We need to make sure that the full reindex doesn't interrupt other indexers from running when `bin/magento indexer:reindex` command is ran.

## How Has This Been Tested?
Locally with Magento 2.3.2 setting the max amount of allowed memory to 1%

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
