### PR TITLE
Add null check after building Nosto product

### DIFF
--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -152,7 +152,6 @@ class Builder
             'nosto_product_load_before',
             ['product' => $nostoProduct, 'magentoProduct' => $product, 'modelFilter' => $modelFilter]
         );
-
         if (!$modelFilter->isValid()) {
             return null;
         }


### PR DESCRIPTION
Remove the cache entry from db if product builder returns `null`. This could happen if the product building fails or if some products are excluded using model filter (https://github.com/Nosto/nosto-magento2/blob/feature/product-caching-index/Model/Product/Builder.php#L156)

## Description
Add null check & remove cache entry if product data is null

## How Has This Been Tested?
Tested locally by indexing non-buildable products.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
