### PR TITLE
Fix the rating helper to check the return type for getRatingSummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.8
+* Fix the compatilibity issue with Magento 2.3.3 in ratings & reviews building 
+
 ### 3.8.7
 * Fix product availability when in single store mode
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN        service mysql start && \
            cd /var/www/html && \
            composer config --global repositories.0 composer https://repo.magento.com && \
            composer config --global http-basic.repo.magento.com $repouser $repopass && \
-           composer create-project magento/community-edition && \
+           composer create-project magento/community-edition:2.3.2 && \
            cd community-edition && \
            composer update && \
            composer config --unset minimum-stability && \

--- a/Helper/Ratings.php
+++ b/Helper/Ratings.php
@@ -36,9 +36,11 @@
 
 namespace Nosto\Tagging\Helper;
 
+use Exception;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Catalog\Model\Product;
+use Magento\Framework\DataObject;
 use Magento\Framework\Registry;
 use Nosto\Tagging\Helper\Data as NostoHelperData;
 use Magento\Store\Model\Store;
@@ -136,7 +138,7 @@ class Ratings extends AbstractHelper
 
                     /** @noinspection PhpUndefinedMethodInspection */
                     $ratings = $this->ratingsFactory->create()->getRichSnippet();
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     $this->resetRegistryProduct();
                     $this->logger->exception($e);
                     return null;
@@ -176,15 +178,31 @@ class Ratings extends AbstractHelper
      */
     private function buildRatingValue(Product $product, Store $store)
     {
-        /** @noinspection PhpUndefinedMethodInspection */
-        if (!$product->getRatingSummary()) {
-            $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
-        }
-
-        /** @noinspection PhpUndefinedMethodInspection */
-        if ($product->getRatingSummary()->getReviewsCount() > 0) {
+        try {
             /** @noinspection PhpUndefinedMethodInspection */
-            return round($product->getRatingSummary()->getRatingSummary() / 20, 1);
+            if (!$product->getRatingSummary()) {
+                $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
+            }
+            $ratingSummary = $product->getRatingSummary();
+            $ratingValue = null;
+            // As of Magento 2.3.3 rating summary returns directly the sum of ratings rather
+            // than DataObject
+            if ($ratingSummary instanceof DataObject) {
+                /** @noinspection PhpUndefinedMethodInspection */
+                if ($ratingSummary->getReviewsCount() > 0
+                    /** @noinspection PhpUndefinedMethodInspection */
+                    && $ratingSummary->getRatingSummary() > 0
+                ) {
+                    $ratingValue = $ratingSummary->getRatingSummary();
+                }
+            } elseif(is_numeric($ratingSummary)) {
+                $ratingValue = $ratingSummary;
+            }
+            if ($ratingValue !== null) {
+                return (float)round($ratingValue / 20, 1);
+            }
+        } catch (Exception $e) {
+            $this->logger->exception($e);
         }
 
         return null;
@@ -200,17 +218,27 @@ class Ratings extends AbstractHelper
      */
     private function buildReviewCount(Product $product, Store $store)
     {
-        /** @noinspection PhpUndefinedMethodInspection */
-        if (!$product->getRatingSummary()) {
-            $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
-        }
-
-        /** @noinspection PhpUndefinedMethodInspection */
-        if ($product->getRatingSummary()->getReviewsCount() > 0) {
+        try {
             /** @noinspection PhpUndefinedMethodInspection */
-            return $product->getRatingSummary()->getReviewsCount();
+            if (!$product->getRatingSummary()) {
+                $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
+            }
+            $ratingSummary = $product->getRatingSummary();
+            $reviewCount = null;
+            // As of Magento 2.3.3 rating summary returns directly the amount of
+            // than DataObject
+            if ($ratingSummary instanceof DataObject) {
+                /** @noinspection PhpUndefinedMethodInspection */
+                if ($ratingSummary->getReviewsCount() > 0) {
+                    $reviewCount = $ratingSummary->getReviewsCount();
+                }
+            } elseif(is_numeric($product->getReviewsCount())) {
+                $reviewCount = (int)$product->getReviewsCount();
+            }
+            return $reviewCount;
+        } catch (Exception $e) {
+            $this->logger->exception($e);
         }
-
         return null;
     }
 

--- a/Helper/Ratings.php
+++ b/Helper/Ratings.php
@@ -183,6 +183,7 @@ class Ratings extends AbstractHelper
             if (!$product->getRatingSummary()) {
                 $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
             }
+            /** @noinspection PhpUndefinedMethodInspection */
             $ratingSummary = $product->getRatingSummary();
             $ratingValue = null;
             // As of Magento 2.3.3 rating summary returns directly the sum of ratings rather
@@ -193,9 +194,10 @@ class Ratings extends AbstractHelper
                     /** @noinspection PhpUndefinedMethodInspection */
                     && $ratingSummary->getRatingSummary() > 0
                 ) {
+                    /** @noinspection PhpUndefinedMethodInspection */
                     $ratingValue = $ratingSummary->getRatingSummary();
                 }
-            } elseif(is_numeric($ratingSummary)) {
+            } elseif (is_numeric($ratingSummary)) {
                 $ratingValue = $ratingSummary;
             }
             if ($ratingValue !== null) {
@@ -223,6 +225,7 @@ class Ratings extends AbstractHelper
             if (!$product->getRatingSummary()) {
                 $this->reviewFactory->create()->getEntitySummary($product, $store->getId());
             }
+            /** @noinspection PhpUndefinedMethodInspection */
             $ratingSummary = $product->getRatingSummary();
             $reviewCount = null;
             // As of Magento 2.3.3 rating summary returns directly the amount of
@@ -230,9 +233,12 @@ class Ratings extends AbstractHelper
             if ($ratingSummary instanceof DataObject) {
                 /** @noinspection PhpUndefinedMethodInspection */
                 if ($ratingSummary->getReviewsCount() > 0) {
+                    /** @noinspection PhpUndefinedMethodInspection */
                     $reviewCount = $ratingSummary->getReviewsCount();
                 }
-            } elseif(is_numeric($product->getReviewsCount())) {
+            /** @noinspection PhpUndefinedMethodInspection */
+            } elseif (is_numeric($product->getReviewsCount())) {
+                /** @noinspection PhpUndefinedMethodInspection */
                 $reviewCount = (int)$product->getReviewsCount();
             }
             return $reviewCount;

--- a/Helper/Ratings.php
+++ b/Helper/Ratings.php
@@ -227,21 +227,20 @@ class Ratings extends AbstractHelper
             }
             /** @noinspection PhpUndefinedMethodInspection */
             $ratingSummary = $product->getRatingSummary();
-            $reviewCount = null;
             // As of Magento 2.3.3 rating summary returns directly the amount of
             // than DataObject
             if ($ratingSummary instanceof DataObject) {
                 /** @noinspection PhpUndefinedMethodInspection */
                 if ($ratingSummary->getReviewsCount() > 0) {
                     /** @noinspection PhpUndefinedMethodInspection */
-                    $reviewCount = $ratingSummary->getReviewsCount();
+                    return (int)$ratingSummary->getReviewsCount();
                 }
             /** @noinspection PhpUndefinedMethodInspection */
             } elseif (is_numeric($product->getReviewsCount())) {
                 /** @noinspection PhpUndefinedMethodInspection */
-                $reviewCount = (int)$product->getReviewsCount();
+                return (int)$product->getReviewsCount();
             }
-            return $reviewCount;
+            return null;
         } catch (Exception $e) {
             $this->logger->exception($e);
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
 
     stage('Phan Analysis') {
       steps {
-        sh "composer create-project magento/community-edition magento"
+        sh "composer create-project magento/community-edition:2.3.2 magento"
         sh "cd magento && composer config minimum-stability dev"
         sh "cd magento && composer config prefer-stable true"
         script {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.8.7",
+  "version": "3.8.8",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.8.7"/>
+    <module name="Nosto_Tagging" setup_version="3.8.8"/>
 </config>


### PR DESCRIPTION
Fix fatal error in building ratings & reviews for Nosto product data.

## Related Issue
#589 

## Motivation and Context
This throws a fatal error if Magento's native ratings and reviews are used for Nosto. 

## How Has This Been Tested?
Tested locally with 2.3.2 and 2.3.3.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
