### PR TITLE
Update 2c.cId cookie lifetime (2 years)

### DIFF
--- a/Model/Customer/Customer.php
+++ b/Model/Customer/Customer.php
@@ -49,9 +49,21 @@ class Customer extends AbstractModel implements CustomerInterface
     const COOKIE_NAME = '2c_cId';
 
     /**
+     * Name of cookie that holds Nosto visitor id dot separated
+     * PHP Can't set if uses underscores.
+     */
+    const COOKIE_NAME_SET = '2c.cId';
+
+    /**
      * Name of cookie used for Webkit's ITP prevention
      */
-    const HTTP_COOKIE_NAME = '2c.cId.http';
+    const HTTP_COOKIE_NAME = '2c_cId_http';
+
+    /**
+     * Name of cookie used for Webkit's ITP prevention
+     * PHP Can't set if underscores are used.
+     */
+    const HTTP_COOKIE_NAME_SET = '2c.cId.http';
 
     /**
      * @inheritdoc

--- a/Model/Customer/Customer.php
+++ b/Model/Customer/Customer.php
@@ -49,6 +49,11 @@ class Customer extends AbstractModel implements CustomerInterface
     const COOKIE_NAME = '2c_cId';
 
     /**
+     * Name of cookie used for Webkit's ITP prevention
+     */
+    const HTTP_COOKIE_NAME = '2c.cId.http';
+
+    /**
      * @inheritdoc
      */
     public function getCustomerId()

--- a/Observer/App/Action/Action.php
+++ b/Observer/App/Action/Action.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Observer\App\Action;
+
+use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Stdlib\Cookie\CookieSizeLimitReachedException;
+use Magento\Framework\Stdlib\Cookie\FailureToSendException;
+use Magento\Framework\Stdlib\CookieManagerInterface;
+use Nosto\Tagging\Model\Customer\Customer;
+use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata;
+
+class Action implements ObserverInterface
+{
+    /**
+     * @var HttpResponse $response
+     */
+    private $response;
+    /**
+     * @var CookieManagerInterface
+     */
+    private $cookieManager;
+
+    /**
+     * Action constructor.
+     * @param HttpResponse $response
+     * @param CookieManagerInterface $cookieManager
+     */
+    public function __construct(
+        HttpResponse $response,
+        CookieManagerInterface $cookieManager
+    ) {
+        $this->response = $response;
+        $this->cookieManager = $cookieManager;
+    }
+
+    /**
+     * @param Observer $observer
+     * @throws InputException
+     * @throws CookieSizeLimitReachedException
+     * @throws FailureToSendException
+     */
+    public function execute(Observer $observer)
+    {
+        $cookieValue = $this->cookieManager->getCookie(Customer::COOKIE_NAME);
+        $cookieMetadata = new PublicCookieMetadata();
+        $cookieMetadata->setDuration(3600 * 24 * (365 * 2)); // 2 Years
+        $this->cookieManager->setPublicCookie(
+            Customer::COOKIE_NAME,
+            $cookieValue,
+            $cookieMetadata
+        );
+    }
+}

--- a/Observer/App/Action/Action.php
+++ b/Observer/App/Action/Action.php
@@ -87,6 +87,7 @@ class Action implements ObserverInterface
      * @throws CookieSizeLimitReachedException
      * @throws FailureToSendException
      * @throws InputException
+     * @suppress PhanUndeclaredMethod
      */
     public function execute(Observer $observer) // @codingStandardsIgnoreLine
     {

--- a/Observer/App/Action/Action.php
+++ b/Observer/App/Action/Action.php
@@ -79,6 +79,9 @@ class Action implements ObserverInterface
     public function execute(Observer $observer)
     {
         $cookieValue = $this->cookieManager->getCookie(Customer::COOKIE_NAME);
+        if (empty($cookieValue)) {
+            return;
+        }
         $cookieMetadata = new PublicCookieMetadata();
         $cookieMetadata->setDuration(3600 * 24 * (365 * 2)); // 2 Years
         $this->cookieManager->setPublicCookie(

--- a/Observer/App/Action/Action.php
+++ b/Observer/App/Action/Action.php
@@ -76,7 +76,7 @@ class Action implements ObserverInterface
      * @throws CookieSizeLimitReachedException
      * @throws FailureToSendException
      */
-    public function execute(Observer $observer)
+    public function execute(Observer $observer) // @codingStandardsIgnoreLine
     {
         $cookieValue = $this->cookieManager->getCookie(Customer::COOKIE_NAME);
         $cookieValueHttp = $this->cookieManager->getCookie(Customer::HTTP_COOKIE_NAME);

--- a/Observer/App/Action/Action.php
+++ b/Observer/App/Action/Action.php
@@ -79,13 +79,17 @@ class Action implements ObserverInterface
     public function execute(Observer $observer)
     {
         $cookieValue = $this->cookieManager->getCookie(Customer::COOKIE_NAME);
-        if (empty($cookieValue)) {
+        $cookieValueHttp = $this->cookieManager->getCookie(Customer::HTTP_COOKIE_NAME);
+
+        if (empty($cookieValue) || ($cookieValue === $cookieValueHttp)) {
             return;
         }
+        // In case 2c.cId changes on the client side, we should update 2c.cId.http
         $cookieMetadata = new PublicCookieMetadata();
         $cookieMetadata->setDuration(3600 * 24 * (365 * 2)); // 2 Years
+        $cookieMetadata->setHttpOnly(true);
         $this->cookieManager->setPublicCookie(
-            Customer::COOKIE_NAME,
+            Customer::HTTP_COOKIE_NAME,
             $cookieValue,
             $cookieMetadata
         );

--- a/Observer/App/Action/Action.php
+++ b/Observer/App/Action/Action.php
@@ -84,14 +84,25 @@ class Action implements ObserverInterface
         if (empty($cookieValue) || ($cookieValue === $cookieValueHttp)) {
             return;
         }
-        // In case 2c.cId changes on the client side, we should update 2c.cId.http
         $cookieMetadata = new PublicCookieMetadata();
         $cookieMetadata->setDuration(3600 * 24 * (365 * 2)); // 2 Years
-        $cookieMetadata->setHttpOnly(true);
-        $this->cookieManager->setPublicCookie(
-            Customer::HTTP_COOKIE_NAME,
-            $cookieValue,
-            $cookieMetadata
-        );
+
+        if (empty($cookieValueHttp)) {
+            $cookieMetadata->setHttpOnly(true);
+            $this->cookieManager->setPublicCookie(
+                Customer::HTTP_COOKIE_NAME_SET,
+                $cookieValue,
+                $cookieMetadata
+            );
+        } elseif ($cookieValue !== $cookieValueHttp) {
+            // In case 2c.cId changes on the client side, means that the cookie has been deleted.
+            // We should update 2c.cId with 2c.cId.http
+            $cookieMetadata->setHttpOnly(false);
+            $this->cookieManager->setPublicCookie(
+                Customer::COOKIE_NAME_SET,
+                $cookieValueHttp,
+                $cookieMetadata
+            );
+        }
     }
 }

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -58,4 +58,7 @@
     <event name="customer_save_before">
         <observer name="nosto_customer_save_after" instance="Nosto\Tagging\Observer\Customer\Save" />
     </event>
+    <event name="catalog_block_product_list_collection">
+        <observer name="nosto_cookie_predispatch" instance="Nosto\Tagging\Observer\App\Action\Action"/>
+    </event>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -58,7 +58,7 @@
     <event name="customer_save_before">
         <observer name="nosto_customer_save_after" instance="Nosto\Tagging\Observer\Customer\Save" />
     </event>
-    <event name="catalog_block_product_list_collection">
+    <event name="layout_load_before">
         <observer name="nosto_cookie_predispatch" instance="Nosto\Tagging\Observer\App\Action\Action"/>
     </event>
 </config>


### PR DESCRIPTION
## Description
This PR intents to copy the cookie value set from nosto.com domain and re-render from the server-side, which prevents ITP to block/wipe the cookie.

## Related Issue
Fixes #607

## Motivation and Context
In ITP 2.3 Cookies are only deleted if they have been saved on local storage. This deletion happens after 7 days. Cookies are saved to local storage if they come from a decorated link (i.e. another website with params on the URI).
So far, I understood that the cookie will only be deleted if the customer does not visit the website within 7 days. Since the 2c.cId is different for each Nosto website, the customer needs to access each merchant's website within 7 days.

## How Has This Been Tested?
Refreshing the cookie and checking its lifetime

## Documentation:
- [ ] Todo

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
