### PR TITLE
Introduce possibility to move the product data building into a cron job

### DIFF
--- a/Console/Command/NostoRebuildInvalidProductData.php
+++ b/Console/Command/NostoRebuildInvalidProductData.php
@@ -99,7 +99,6 @@ class NostoRebuildInvalidProductData extends Command
             $io->success('Nosto product data rebuild manually');
         } catch (\Exception $e) {
             $io->error(sprintf('An error occurred - message was %s', $e->getMessage()));
-            return;
         }
     }
 

--- a/Console/Command/NostoRebuildInvalidProductData.php
+++ b/Console/Command/NostoRebuildInvalidProductData.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Console\Command;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
+use Nosto\Tagging\Cron\ProductDataCron;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Class NostoRebuildInvalidProductData
+ * This command is mainly for debugging purposes - the cron job should do the trick
+ * @package Nosto\Tagging\Console\Command
+ */
+class NostoRebuildInvalidProductData extends Command
+{
+    /**
+     * @var ProductDataCron
+     */
+    private $productDataCron;
+
+    /** @var State */
+    private $appState;
+
+    /**
+     * NostoConfigConnectCommand constructor.
+     * @param ProductDataCron $productDataCron
+     * @param State $appState
+     */
+    public function __construct(
+        ProductDataCron $productDataCron,
+        State $appState
+    ) {
+        $this->productDataCron = $productDataCron;
+        $this->appState = $appState;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('nosto:data:rebuild-invalid-products')
+            ->setDescription(
+                'Rebuilds the Nosto product data for "dirty" products - '
+                . 'this command is meant mainly for debugging purposes'
+            );
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        try {
+            $this->handleArea();
+            $this->productDataCron->execute();
+            $io->success('Nosto product data rebuild manually');
+        } catch (\Exception $e) {
+            $io->error(sprintf('An error occurred - message was %s', $e->getMessage()));
+            return;
+        }
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function handleArea()
+    {
+        try {
+            $originalArea = $this->appState->getAreaCode();
+        } catch (LocalizedException $e) {
+            $originalArea = null;
+        }
+        if ($originalArea === null) {
+            $this->appState->setAreaCode(Area::AREA_FRONTEND);
+        }
+    }
+}

--- a/Cron/ProductDataCron.php
+++ b/Cron/ProductDataCron.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright (c) 2019, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2019 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Cron;
+
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Nosto\Exception\MemoryOutOfBoundsException;
+use Nosto\NostoException;
+use Nosto\Tagging\Helper\Account as NostoAccountHelper;
+use Nosto\Tagging\Helper\Data as NostoDataHelper;
+use Nosto\Tagging\Logger\Logger;
+use Nosto\Tagging\Model\Product\Cache;
+use Nosto\Tagging\Model\Product\Cache\CacheRepository;
+use Nosto\Tagging\Model\Service\Cache\CacheService;
+use Nosto\Tagging\Util\PagingIterator;
+
+/**
+ * Cronjob class that rebuilds the product index
+ *
+ * @package Nosto\Tagging\Cron
+ */
+class ProductDataCron
+{
+    /** @var Logger */
+    protected $logger;
+
+    /** @var NostoAccountHelper */
+    private $nostoAccountHelper;
+
+    /** @var CacheRepository */
+    private $cacheRepository;
+
+    /** @var int */
+    private $batchSize;
+
+    /** @var CacheService */
+    private $cacheService;
+
+    /** @var NostoDataHelper */
+    private $nostoDataHelper;
+
+    /**
+     * ProductDataCron constructor.
+     * @param NostoAccountHelper $nostoAccountHelper
+     * @param NostoDataHelper $nostoDataHelper
+     * @param CacheRepository $cacheRepository
+     * @param CacheService $cacheService
+     * @param Logger $logger
+     * @param $batchSize
+     */
+    public function __construct(
+        NostoAccountHelper $nostoAccountHelper,
+        NostoDataHelper $nostoDataHelper,
+        CacheRepository $cacheRepository,
+        CacheService $cacheService,
+        Logger $logger,
+        $batchSize
+    ) {
+        $this->logger = $logger;
+        $this->cacheRepository = $cacheRepository;
+        $this->nostoAccountHelper = $nostoAccountHelper;
+        $this->nostoDataHelper = $nostoDataHelper;
+        $this->cacheService = $cacheService;
+        $this->batchSize = $batchSize;
+    }
+
+    /**
+     * Executes a cron job for rebuilding invalid product data
+     * @throws Exception
+     */
+    public function execute()
+    {
+        $stores = $this->nostoAccountHelper->getStoresWithNosto();
+        $this->logger->debug(
+            sprintf(
+                'Starting to rebuild product cache for dirty products - Nosto is installed for %d stores',
+                count($stores)
+            )
+        );
+        foreach ($stores as $store) {
+            if ($this->nostoDataHelper->isProductDataBuildInCronEnabled($store) === false) {
+                continue;
+            }
+            $productCollection = $this->cacheRepository->getOutOfSyncInStore($store);
+            $productCollection->setPageSize($this->batchSize);
+            $iterator = new PagingIterator($productCollection);
+            foreach ($iterator as $page) {
+                $ids = $page->toArray([Cache::ID])['items'];
+                try {
+                    $this->cacheService->generateProductsInStore($store, $ids);
+                } catch (MemoryOutOfBoundsException $e) {
+                    $this->logger->error($e->getMessage());
+                } catch (NostoException $e) {
+                    $this->logger->error($e->getMessage());
+                } catch (LocalizedException $e) {
+                    $this->logger->error($e->getMessage());
+                }
+            }
+        }
+        $this->logger->debug('Product data cron ran');
+    }
+}

--- a/Cron/ProductDataCron.php
+++ b/Cron/ProductDataCron.php
@@ -118,6 +118,14 @@ class ProductDataCron
             }
             $productCollection = $this->cacheRepository->getOutOfSyncInStore($store);
             $productCollection->setPageSize($this->batchSize);
+            $this->logger->info(
+                sprintf(
+                    'Starting to rebuild %d dirty products in a cron job with batch size %d for store %s',
+                    $productCollection->getSize(),
+                    $this->batchSize,
+                    $store->getCode()
+                )
+            );
             $iterator = new PagingIterator($productCollection);
             foreach ($iterator as $page) {
                 $ids = $page->toArray([Cache::ID])['items'];
@@ -131,6 +139,12 @@ class ProductDataCron
                     $this->logger->error($e->getMessage());
                 }
             }
+            $this->logger->info(
+                sprintf(
+                    'Finished rebuild for store %s',
+                    $store->getCode()
+                )
+            );
         }
         $this->logger->debug('Product data cron ran');
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -145,6 +145,11 @@ class Data extends AbstractHelper
     const XML_PATH_TRACK_MULTI_CHANNEL_ORDERS = 'nosto/flags/track_multi_channel_orders';
 
     /**
+     * Path to the configuration object that stores the product data build configuration (cron / indexer)
+     */
+    const XML_PATH_PRODUCT_DATA_BUILD_IN_CRON = 'nosto/flags/product_data_build_in_cron';
+
+    /**
      * Path to the configuration object for pricing variations
      */
     const XML_PATH_PRICING_VARIATION = 'nosto/multicurrency/pricing_variation';
@@ -420,6 +425,17 @@ class Data extends AbstractHelper
     public function isMultiChannelOrderTrackingEnabled(StoreInterface $store = null)
     {
         return (bool)$this->getStoreConfig(self::XML_PATH_TRACK_MULTI_CHANNEL_ORDERS, $store);
+    }
+
+    /**
+     * Returns if product data should be built in cron
+     *
+     * @param StoreInterface|null $store
+     * @return bool
+     */
+    public function isProductDataBuildInCronEnabled(StoreInterface $store = null)
+    {
+        return (bool)$this->getStoreConfig(self::XML_PATH_PRODUCT_DATA_BUILD_IN_CRON, $store);
     }
 
     /**

--- a/Model/Indexer/DataIndexer.php
+++ b/Model/Indexer/DataIndexer.php
@@ -135,16 +135,16 @@ class DataIndexer extends AbstractIndexer
                     $store->getCode()
                 )
             );
-            return;
-        }
-        try {
-            $this->nostoCacheService->generateProductsInStore($store, $ids);
-        } catch (MemoryOutOfBoundsException $e) {
-            $this->nostoLogger->error($e->getMessage());
-        } catch (NostoException $e) {
-            $this->nostoLogger->error($e->getMessage());
-        } catch (LocalizedException $e) {
-            $this->nostoLogger->error($e->getMessage());
+        } else {
+            try {
+                $this->nostoCacheService->generateProductsInStore($store, $ids);
+            } catch (MemoryOutOfBoundsException $e) {
+                $this->nostoLogger->error($e->getMessage());
+            } catch (NostoException $e) {
+                $this->nostoLogger->error($e->getMessage());
+            } catch (LocalizedException $e) {
+                $this->nostoLogger->error($e->getMessage());
+            }
         }
     }
 }

--- a/Model/Product/Cache/CacheRepository.php
+++ b/Model/Product/Cache/CacheRepository.php
@@ -124,6 +124,18 @@ class CacheRepository implements ProductCacheRepositoryInterface
     }
 
     /**
+     * @param Store $store
+     * @return CacheCollection
+     */
+    public function getOutOfSyncInStore(Store $store)
+    {
+        /* @var CacheCollection $collection */
+        return $this->cacheCollectionFactory->create()
+            ->addOutOfSyncFilter()
+            ->addStoreFilter($store);
+    }
+
+    /**
      * @inheritdoc
      */
     public function getTotalDirty(Store $store)

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -213,6 +213,14 @@
                     </comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="product_data_build_in_cron" translate="label comment" type="select" sortOrder="150"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Build product data cache in cron</label>
+                    <comment>
+                        <![CDATA[Set this yes if you want the cached product data to be built in a cron job instead of in Magento indexer]]>
+                    </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
             <group id="attributes" translate="label" type="text" sortOrder="40" showInDefault="1"
                    showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -24,6 +24,7 @@
                 <indexer_memory>50</indexer_memory>
                 <tag_date_published>0</tag_date_published>
                 <track_multi_channel_orders>1</track_multi_channel_orders>
+                <product_data_build_in_cron>0</product_data_build_in_cron>
             </flags>
             <multicurrency>
                 <method>undefined</method>

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -9,4 +9,13 @@
         <history_failure_lifetime>600</history_failure_lifetime>
         <use_separate_process>1</use_separate_process>
     </group>
+    <group id="nosto_rebuild_product_data_group">
+        <schedule_generate_every>1</schedule_generate_every>
+        <schedule_ahead_for>4</schedule_ahead_for>
+        <schedule_lifetime>15</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>60</history_success_lifetime>
+        <history_failure_lifetime>600</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
 </config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -12,4 +12,9 @@
             <schedule>0 * * * *</schedule>
         </job>
     </group>
+    <group id="nosto_rebuild_product_data_group">
+        <job name="nosto_rebuild_product_data" instance="Nosto\Tagging\Cron\ProductDataCron" method="execute">
+            <schedule>*/5 * * * *</schedule>
+        </job>
+    </group>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -83,6 +83,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Nosto\Tagging\Console\Command\NostoRebuildInvalidProductData">
+        <arguments>
+            <argument name="productDataCron" xsi:type="object">Nosto\Tagging\Cron\ProductDataCron\Proxy</argument>
+        </arguments>
+    </type>
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">
@@ -94,6 +99,9 @@
                 </item>
                 <item name="nosto_generate_customer_reference_command" xsi:type="object">
                     Nosto\Tagging\Console\Command\NostoGenerateCustomerReferenceCommand
+                </item>
+                <item name="nosto_rebuild_invalid_product_data" xsi:type="object">
+                    Nosto\Tagging\Console\Command\NostoRebuildInvalidProductData
                 </item>
             </argument>
         </arguments>
@@ -166,7 +174,7 @@
     <type name="Nosto\Tagging\Model\Product\CollectionBuilder">
         <arguments>
             <argument name="productService" xsi:type="object">
-                Nosto\Tagging\Model\Service\Product\CachingProductService
+                Nosto\Tagging\Model\Service\Product\DefaultProductService
             </argument>
         </arguments>
     </type>
@@ -208,6 +216,23 @@
         <arguments>
             <argument name="intervalHours" xsi:type="number">4</argument>
             <argument name="productLimit" xsi:type="number">1000</argument>
+        </arguments>
+    </type>
+    <type name="Nosto\Tagging\Cron\ProductDataCron">
+        <arguments>
+            <argument name="nostoAccountHelper" xsi:type="object">
+                Nosto\Tagging\Helper\Account\Proxy
+            </argument>
+            <argument name="nostoDataHelper" xsi:type="object">
+                Nosto\Tagging\Helper\Data\Proxy
+            </argument>
+            <argument name="cacheRepository" xsi:type="object">
+                Nosto\Tagging\Model\Product\Cache\CacheRepository\Proxy
+            </argument>
+            <argument name="cacheService" xsi:type="object">
+                Nosto\Tagging\Model\Service\Cache\CacheService\Proxy
+            </argument>
+            <argument name="batchSize" xsi:type="number">1000</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Model\Service\Sync\Upsert\AsyncBulkPublisher">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -174,7 +174,7 @@
     <type name="Nosto\Tagging\Model\Product\CollectionBuilder">
         <arguments>
             <argument name="productService" xsi:type="object">
-                Nosto\Tagging\Model\Service\Product\DefaultProductService
+                Nosto\Tagging\Model\Service\Product\CachingProductService
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION

## Description
Introduce a setting for moving the product data building into a cron job from M2 indexer.

## Related Issue
#629 

## Motivation and Context
Our indexer blocks the other indexers as well and the product data generation can still take hours with large catalogs and multiple store views.   

## How Has This Been Tested?
Tested locally by running in both modes. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
