### PR TITLE
Hide Nosto customer reference for registered customer account edit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.10.5
+* Hide Nosto customer reference for registered customers in account edit view
+
 ### 3.10.4
 * Bump SDK version to 4.0.10 to fix OrderStatus Handlers throwing exceptions
 

--- a/Setup/CoreData.php
+++ b/Setup/CoreData.php
@@ -36,17 +36,23 @@
 
 namespace Nosto\Tagging\Setup;
 
-use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Customer\Model\Customer;
-use Magento\Eav\Model\Entity\Attribute\SetFactory as AttributeSetFactory;
 use Magento\Customer\Setup\CustomerSetupFactory;
+use Magento\Eav\Model\Entity\Attribute\SetFactory as AttributeSetFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Nosto\Tagging\Helper\Data as NostoHelperData;
 
 abstract class CoreData
 {
+
+    /** @var CustomerSetupFactory */
     private $customerSetupFactory;
+
+    /** @var AttributeSetFactory */
     private $attributeSetFactory;
+
+    private $customerReferenceForms = ['adminhtml_customer'];
 
     /**
      * CoreData constructor.
@@ -68,15 +74,15 @@ abstract class CoreData
      */
     public function addCustomerReference(ModuleDataSetupInterface $setup)
     {
-        $customerSetup = $this->customerSetupFactory->create(['setup' => $setup]);
+        $customerEavSetup = $this->customerSetupFactory->create(['setup' => $setup]);
 
-        $customerEntity = $customerSetup->getEavConfig()->getEntityType(Customer::ENTITY);
+        $customerEntity = $customerEavSetup->getEavConfig()->getEntityType(Customer::ENTITY);
         $attributeSetId = (int)$customerEntity->getDefaultAttributeSetId();
 
         $attributeSet = $this->attributeSetFactory->create();
         $attributeGroupId = $attributeSet->getDefaultGroupId($attributeSetId);
 
-        $customerSetup->addAttribute(
+        $customerEavSetup->addAttribute(
             Customer::ENTITY,
             NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME,
             [
@@ -93,7 +99,7 @@ abstract class CoreData
             ]
         );
 
-        $attribute = $customerSetup->getEavConfig()->getAttribute(
+        $attribute = $customerEavSetup->getEavConfig()->getAttribute(
             Customer::ENTITY,
             NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME
         );
@@ -102,10 +108,31 @@ abstract class CoreData
             [
                 'attribute_set_id' => $attributeSetId,
                 'attribute_group_id' => $attributeGroupId,
-                'used_in_forms' => ['adminhtml_customer', 'customer_account_edit'],
+                'used_in_forms' => $this->customerReferenceForms,
             ]
         );
 
+        $attribute->save();
+    }
+
+    /**
+     * Sets the attribute Nosto customer reference to be only editable in admin
+     *
+     * @param ModuleDataSetupInterface $setup
+     * @throws LocalizedException
+     */
+    public function alterCustomerReferenceNonEditable(ModuleDataSetupInterface $setup)
+    {
+        $customerSetup = $this->customerSetupFactory->create(['setup' => $setup]);
+        $attribute = $customerSetup->getEavConfig()->getAttribute(
+            Customer::ENTITY,
+            NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME
+        );
+        $attribute->addData(
+            [
+                'used_in_forms' => $this->customerReferenceForms
+            ]
+        );
         $attribute->save();
     }
 }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -38,14 +38,14 @@ namespace Nosto\Tagging\Setup;
 
 use Magento\Customer\Setup\CustomerSetupFactory;
 use Magento\Eav\Model\Entity\Attribute\SetFactory as AttributeSetFactory;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Store\Model\ScopeInterface;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Url as NostoHelperUrl;
-use Magento\Framework\App\Config\Storage\WriterInterface;
-use Magento\Store\Model\ScopeInterface;
-use Magento\Framework\Exception\LocalizedException;
 
 class UpgradeData extends CoreData implements UpgradeDataInterface
 {
@@ -91,9 +91,11 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
         if (version_compare($fromVersion, '3.1.0', '<=')) {
             $this->insertStoreDomain();
         }
-
         if (version_compare($fromVersion, '3.6.0', '<=')) {
             $this->addCustomerReference($setup);
+        }
+        if (version_compare($fromVersion, '3.10.4', '<=')) {
+            $this->alterCustomerReferenceNonEditable($setup);
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="3.10.4"/>
+    <module name="Nosto_Tagging" setup_version="3.10.5"/>
 </config>


### PR DESCRIPTION
# Description
Define attribute Nosto customer reference to not to be editable by registered customers.  

## Related Issue
#599 

## Motivation and Context
Customers should not be able to edit the reference.

## How Has This Been Tested?
Tested locally by running the setup upgrade multiple times. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
