### PR TITLE
Generate customer reference on setup upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
-
 # not released
 * Remove logic for sending cart updates to Nosto from server side
+* Generate customer reference for all registered customers automatically during setup upgrade
 
 ### 4.0.0-rc7 (pre-release)
 * Amend fixes from [3.10.5](###3.10.5)

--- a/Setup/CoreData.php
+++ b/Setup/CoreData.php
@@ -37,11 +37,16 @@
 namespace Nosto\Tagging\Setup;
 
 use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\CustomerFactory;
+use Magento\Customer\Model\ResourceModel\Customer as CustomerResource;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerCollectionFactory;
 use Magento\Customer\Setup\CustomerSetupFactory;
 use Magento\Eav\Model\Entity\Attribute\SetFactory as AttributeSetFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Nosto\Tagging\Helper\Data as NostoHelperData;
+use Nosto\Tagging\Util\Customer as CustomerUtil;
+use Nosto\Tagging\Util\PagingIterator;
 use Zend_Validate_Exception;
 
 abstract class CoreData
@@ -55,17 +60,29 @@ abstract class CoreData
 
     private $customerReferenceForms = ['adminhtml_customer'];
 
+    /** @var CustomerFactory */
+    private $customerCollectionFactory;
+
+    /** @var CustomerResource */
+    private $customerResource;
+
     /**
      * CoreData constructor.
      * @param CustomerSetupFactory $customerSetupFactory
      * @param AttributeSetFactory $attributeSetFactory
+     * @param CustomerCollectionFactory $customerCollectionFactory
+     * @param CustomerResource $customerResource
      */
     public function __construct(
         CustomerSetupFactory $customerSetupFactory,
-        AttributeSetFactory $attributeSetFactory
+        AttributeSetFactory $attributeSetFactory,
+        CustomerCollectionFactory $customerCollectionFactory,
+        CustomerResource $customerResource
     ) {
         $this->customerSetupFactory = $customerSetupFactory;
         $this->attributeSetFactory = $attributeSetFactory;
+        $this->customerCollectionFactory = $customerCollectionFactory;
+        $this->customerResource = $customerResource;
     }
 
     /**
@@ -137,5 +154,30 @@ abstract class CoreData
             ]
         );
         $attribute->save();
+    }
+
+    /**
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     * @throws \Nosto\NostoException
+     */
+    public function populateCustomerReference()
+    {
+        $customerCollection = $this->customerCollectionFactory->create()
+        ->addAttributeToSelect('*')
+        ->setPageSize(1000);
+        $iterator = new PagingIterator($customerCollection);
+        /* @var Customer $customer */
+        foreach ($iterator as $page) {
+            foreach ($page as $customer) {
+                if (!$customer->getCustomAttribute(NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME)) {
+                    $customer->setData(
+                        NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME,
+                        CustomerUtil::generateCustomerReference($customer)
+                    );
+                    $this->customerResource->save($customer);
+                }
+            }
+        }
     }
 }

--- a/Setup/CoreData.php
+++ b/Setup/CoreData.php
@@ -175,7 +175,7 @@ abstract class CoreData
                         NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME,
                         CustomerUtil::generateCustomerReference($customer)
                     );
-                    $this->customerResource->save($customer);
+                    $this->customerResource->save($customer); // @codingStandardsIgnoreLine
                 }
             }
         }

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -49,9 +49,12 @@ class InstallData extends CoreData implements InstallDataInterface
      * @param ModuleContextInterface $context
      * @throws LocalizedException
      * @throws Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     * @throws \Nosto\NostoException
      */
     public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context) // @codingStandardsIgnoreLine
     {
         $this->addCustomerReference($setup);
+        $this->populateCustomerReference();
     }
 }


### PR DESCRIPTION
#  Description
Generate customer reference for all registered customers during setup upgrade

## Related Issue
#371 

## Motivation and Context
When sending order data to Nosto either customer id or customer reference must be present.

## How Has This Been Tested?
Tested locally by removing customer references for all registered customers and ran the setup upgrade.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
