### PR TITLE
Don't drop the product queue table during setup upgrade

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -68,13 +68,6 @@ class UpgradeSchema extends Core implements UpgradeSchemaInterface
             );
         }
 
-        if (version_compare($fromVersion, '4.0.0-rc1', '<')) {
-            $this->createProductCacheTable($setup);
-            if ($connection->isTableExists(self::PRODUCT_QUEUE_TABLE)) {
-                $connection->dropTable(self::PRODUCT_QUEUE_TABLE);
-            }
-        }
-
         $setup->endSetup();
     }
 }


### PR DESCRIPTION
If the module must be downgrade from 4.x to 3.x the product queue table is missing and  will not be auto-generated without manually updating the module version in db and re-running setup:upgrade 

## How Has This Been Tested?
Tested locally by upgrading to this version and then downgrading  

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
