### PR TITLE
Improve new order detection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 4.0.1
+* Make the new order detection more fault tolerant by comparing also updated at and created at timestamps
+
 # 4.0.0
 **New features (performance improvements)**
 * Introduce cache for Nosto product data to speedup the product tagging added to the product pages

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -36,6 +36,7 @@
 
 namespace Nosto\Tagging\Observer\Order;
 
+use DateTime;
 use Exception;
 use Magento\Customer\Api\CustomerRepositoryInterface as MagentoCustomerRepository;
 use Magento\Framework\Event\Observer;
@@ -76,6 +77,7 @@ class Save implements ObserverInterface
     private $magentoCustomerRepository;
     private $orderStatusBuilder;
     private static $sent = [];
+    private $intervalForNew;
 
     /** @noinspection PhpUndefinedClassInspection */
     /**
@@ -90,6 +92,7 @@ class Save implements ObserverInterface
      * @param IndexerRegistry $indexerRegistry
      * @param NostoHelperUrl $nostoHelperUrl
      * @param MagentoCustomerRepository $magentoCustomerRepository
+     * @param int $intervalForNew
      */
     public function __construct(
         NostoHelperData $nostoHelperData,
@@ -102,7 +105,8 @@ class Save implements ObserverInterface
         NostoOrderStatusBuilder $orderStatusBuilder,
         IndexerRegistry $indexerRegistry,
         NostoHelperUrl $nostoHelperUrl,
-        MagentoCustomerRepository $magentoCustomerRepository
+        MagentoCustomerRepository $magentoCustomerRepository,
+        $intervalForNew
     ) {
         $this->nostoHelperData = $nostoHelperData;
         $this->nostoHelperAccount = $nostoHelperAccount;
@@ -114,6 +118,7 @@ class Save implements ObserverInterface
         $this->indexer = $indexerRegistry->get(InvalidateIndexer::INDEXER_ID);
         $this->nostoHelperUrl = $nostoHelperUrl;
         $this->magentoCustomerRepository = $magentoCustomerRepository;
+        $this->intervalForNew = $intervalForNew;
     }
 
     /**
@@ -148,13 +153,31 @@ class Save implements ObserverInterface
             );
             if ($nostoAccount !== null) {
                 //Check if order is new or updated
-                if ($order->getState() === Order::STATE_NEW) {
+                if ($this->isNewOrder($order)) {
                     $this->sendNewOrder($order, $nostoAccount, $store);
                 } else {
                     $this->sendOrderStatusUpdated($order, $nostoAccount);
                 }
                 self::$sent[] = $order->getId();
             }
+        }
+    }
+
+    /**
+     *
+     * @param Order $order
+     * @return string|null
+     */
+    public function isNewOrder(Order $order)
+    {
+        try {
+            $updated = new DateTime($order->getUpdatedAt());
+            $created = new DateTime($order->getCreatedAt());
+            $diff = $updated->getTimestamp() - $created->getTimestamp();
+            return $order->getState() === Order::STATE_NEW && $diff <= $this->intervalForNew;
+        } catch (\Exception $e) {
+            $this->logger->exception($e);
+            return true;
         }
     }
 

--- a/Observer/Order/Save.php
+++ b/Observer/Order/Save.php
@@ -164,9 +164,10 @@ class Save implements ObserverInterface
     }
 
     /**
+     * Detects if the order is new (the first time the order is saved)
      *
      * @param Order $order
-     * @return string|null
+     * @return bool
      */
     public function isNewOrder(Order $order)
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -88,6 +88,11 @@
             <argument name="productDataCron" xsi:type="object">Nosto\Tagging\Cron\ProductDataCron\Proxy</argument>
         </arguments>
     </type>
+    <type name="Nosto\Tagging\Observer\Order\Save">
+        <arguments>
+            <argument name="intervalForNew" xsi:type="number">1</argument>
+        </arguments>
+    </type>
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.0"/>
+    <module name="Nosto_Tagging" setup_version="4.0.1"/>
 </config>


### PR DESCRIPTION
## Description
Add comparison of order created and order updated timestamps to detect more realiably newly created orders.  

## Related Issue
#644

## Motivation and Context
We should not send orders but order status updates when order status is changed.

## How Has This Been Tested?
Tested locally by creating orders & changing the statuses (hold / unhold)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
