### PR TITLE
Hotfix - 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 4.0.2
+* Fix an issue where setup:upgrade could crash if customer migration is faulty
+
 # 4.0.1
 * Make the new order detection more fault tolerant by comparing also updated at and created at timestamps
 

--- a/Setup/CoreData.php
+++ b/Setup/CoreData.php
@@ -48,6 +48,7 @@ use Nosto\Tagging\Helper\Data as NostoHelperData;
 use Nosto\Tagging\Util\Customer as CustomerUtil;
 use Nosto\Tagging\Util\PagingIterator;
 use Zend_Validate_Exception;
+use Nosto\Tagging\Logger\Logger;
 
 abstract class CoreData
 {
@@ -66,23 +67,29 @@ abstract class CoreData
     /** @var CustomerResource */
     private $customerResource;
 
+    /** @var Logger */
+    private $logger;
+
     /**
      * CoreData constructor.
      * @param CustomerSetupFactory $customerSetupFactory
      * @param AttributeSetFactory $attributeSetFactory
      * @param CustomerCollectionFactory $customerCollectionFactory
      * @param CustomerResource $customerResource
+     * @param Logger $logger
      */
     public function __construct(
         CustomerSetupFactory $customerSetupFactory,
         AttributeSetFactory $attributeSetFactory,
         CustomerCollectionFactory $customerCollectionFactory,
-        CustomerResource $customerResource
+        CustomerResource $customerResource,
+        Logger $logger
     ) {
         $this->customerSetupFactory = $customerSetupFactory;
         $this->attributeSetFactory = $attributeSetFactory;
         $this->customerCollectionFactory = $customerCollectionFactory;
         $this->customerResource = $customerResource;
+        $this->logger = $logger;
     }
 
     /**
@@ -175,7 +182,11 @@ abstract class CoreData
                         NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME,
                         CustomerUtil::generateCustomerReference($customer)
                     );
-                    $this->customerResource->save($customer); // @codingStandardsIgnoreLine
+                    try {
+                        $this->customerResource->save($customer); // @codingStandardsIgnoreLine
+                    } catch (\Exception $e) {
+                        $this->logger->exception($e);
+                    }
                 }
             }
         }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -49,6 +49,7 @@ use Magento\Store\Model\ScopeInterface;
 use Nosto\NostoException;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Url as NostoHelperUrl;
+use Nosto\Tagging\Logger\Logger;
 use Zend_Validate_Exception;
 
 class UpgradeData extends CoreData implements UpgradeDataInterface
@@ -71,6 +72,7 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
      * @param AttributeSetFactory $attributeSetFactory
      * @param CustomerCollectionFactory $customerCollectionFactory
      * @param CustomerResource $customerResource
+     * @param Logger $logger
      */
     public function __construct(
         NostoHelperAccount $nostoHelperAccount,
@@ -79,7 +81,8 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
         CustomerSetupFactory $customerSetupFactory,
         AttributeSetFactory $attributeSetFactory,
         CustomerCollectionFactory $customerCollectionFactory,
-        CustomerResource $customerResource
+        CustomerResource $customerResource,
+        Logger $logger
     ) {
         $this->nostoHelperAccount = $nostoHelperAccount;
         $this->nostoHelperUrl = $nostoHelperUrl;
@@ -88,7 +91,8 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
             $customerSetupFactory,
             $attributeSetFactory,
             $customerCollectionFactory,
-            $customerResource
+            $customerResource,
+            $logger
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.1"/>
+    <module name="Nosto_Tagging" setup_version="4.0.2"/>
 </config>


### PR DESCRIPTION
## Description
Fixes an issue where setup:upgrade could crash if customer migration is faulty.

## Related Issue
Closes #646 and refers #647 

## Motivation and Context
The crash would prevent updating the extension.

## How Has This Been Tested?
Locally by running the command bellow after upgrading the version:
```
bin/magento module:enable --clear-static-content Nosto_Tagging; bin/magento setup:upgrade; bin/magento setup:di:compile; bin/magento setup:static-content:deploy; bin/magento cache:clean
```

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
