### PR TITLE
Hotfix 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 4.0.3
+* `setup:upgrade` for customer now saves only customer reference instead of entire customer object
+
 # 4.0.2
 * Fix an issue where setup:upgrade could crash if customer migration is faulty
 

--- a/Setup/CoreData.php
+++ b/Setup/CoreData.php
@@ -36,6 +36,7 @@
 
 namespace Nosto\Tagging\Setup;
 
+use Exception;
 use Magento\Customer\Model\Customer;
 use Magento\Customer\Model\CustomerFactory;
 use Magento\Customer\Model\ResourceModel\Customer as CustomerResource;
@@ -171,20 +172,23 @@ abstract class CoreData
     public function populateCustomerReference()
     {
         $customerCollection = $this->customerCollectionFactory->create()
-        ->addAttributeToSelect('*')
+        ->addAttributeToSelect(NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME)
         ->setPageSize(1000);
         $iterator = new PagingIterator($customerCollection);
         /* @var Customer $customer */
         foreach ($iterator as $page) {
             foreach ($page as $customer) {
-                if (!$customer->getCustomAttribute(NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME)) {
+                if (!$customer->getData(NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME)) {
                     $customer->setData(
                         NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME,
                         CustomerUtil::generateCustomerReference($customer)
                     );
                     try {
-                        $this->customerResource->save($customer); // @codingStandardsIgnoreLine
-                    } catch (\Exception $e) {
+                        $this->customerResource->saveAttribute(
+                            $customer,
+                            NostoHelperData::NOSTO_CUSTOMER_REFERENCE_ATTRIBUTE_NAME
+                        );
+                    } catch (Exception $e) {
                         $this->logger->exception($e);
                     }
                 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.2"/>
+    <module name="Nosto_Tagging" setup_version="4.0.3"/>
 </config>


### PR DESCRIPTION
## Description
`setup:upgrade` should only save customer reference instead of the whole customer object

## Related Issue
Refers to #646

## Motivation and Context
This can cause issues and slow-downs when migrating a massive amount of customer data.

## How Has This Been Tested?
- [X] Locally with Magento 2.3.1

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
