### PR TITLE
Ignore /magento folder in for reduced package filesize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ pub
 bin
 phan.xml
 chk*xml
-magento/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pub
 bin
 phan.xml
 chk*xml
+magento/

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     ]
   },
   "archive": {
-    "exclude": ["Jenkinsfile", "Dockerfile", ".DS_STORE", ".idea", ".phan", ".docker", "ruleset.xml", "phan.*", ".gitignore", "build.xml", ".github", "supervisord.conf", "entrypoint.sh"]
+    "exclude": ["Jenkinsfile", "Dockerfile", ".DS_STORE", ".idea", ".phan", ".docker", "ruleset.xml", "phan.*", ".gitignore", "build.xml", ".github", "supervisord.conf", "entrypoint.sh", "/magento"]
   },
   "config": {
     "process-timeout":0


### PR DESCRIPTION
Magento marketplace has a 30MB limit to upload the package. Removing the /magento from the archive solves the issue.