### PR TITLE
Handle large product data & prevent serialization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
 # 4.0.4
-* Store cahced Nosto product data as a base64 encoded string in database to avoid problems with character sets and collation
+* Store cached Nosto product data as a base64 encoded string in database to avoid problems with character sets and collation
 * Alter the type of cached product to be longtext to allow saving large product data sets
 
 # 4.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
 # 4.0.4
-* Store cached Nosto product data as a base64 encoded string in database to avoid problems with character sets and collation
+* Store cached Nosto product data as a base64 encoded string in database to avoid problems with character sets and collations
 * Alter the type of cached product to be longtext to allow saving large product data sets
 
 # 4.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 4.0.4
+* Store cahced Nosto product data as a base64 encoded string in database to avoid problems with character sets and collation
+* Alter the type of cached product to be longtext to allow saving large product data sets
+
 # 4.0.3
 * `setup:upgrade` for customer now saves only customer reference instead of entire customer object
 

--- a/Model/Service/Cache/CacheService.php
+++ b/Model/Service/Cache/CacheService.php
@@ -417,9 +417,14 @@ class CacheService extends AbstractService
                 $this->cacheRepository->delete($productIndex);
                 return null;
             }
-            $nostoCachedProduct = $this->productSerializer->fromString(
-                $productIndex->getProductData()
-            );
+            try {
+                $nostoCachedProduct = $this->productSerializer->fromString(
+                    $productIndex->getProductData()
+                );
+            } catch (\Exception $e) {
+                $this->getLogger()->exception($e);
+                $nostoCachedProduct = null;
+            }
             if ($nostoCachedProduct instanceof NostoProductInterface === false ||
                 (
                     $nostoProduct instanceof NostoProductInterface

--- a/Model/Service/Product/DefaultProductSerializer.php
+++ b/Model/Service/Product/DefaultProductSerializer.php
@@ -49,7 +49,7 @@ class DefaultProductSerializer implements ProductSerializerInterface
      */
     public function fromString($data)
     {
-        return unserialize($data, [Product::class]); // @codingStandardsIgnoreLine
+        return unserialize(base64_decode($data), [Product::class]); // @codingStandardsIgnoreLine
     }
 
     /**
@@ -57,6 +57,6 @@ class DefaultProductSerializer implements ProductSerializerInterface
      */
     public function toString(ProductInterface $product)
     {
-        return serialize($product);  // @codingStandardsIgnoreLine
+        return base64_encode(serialize($product));  // @codingStandardsIgnoreLine
     }
 }

--- a/Model/Service/Product/SanitizingProductService.php
+++ b/Model/Service/Product/SanitizingProductService.php
@@ -39,20 +39,27 @@ namespace Nosto\Tagging\Model\Service\Product;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Nosto\Object\Product\Product;
+use Nosto\Tagging\Logger\Logger;
 
 class SanitizingProductService implements ProductServiceInterface
 {
     /** @var ProductServiceInterface */
     private $nostoProductService;
 
+    /** @var Logger */
+    private $logger;
+
     /**
      * DefaultProductService constructor.
      * @param ProductServiceInterface $nostoProductService
+     * @param Logger $logger
      */
     public function __construct(
-        ProductServiceInterface $nostoProductService
+        ProductServiceInterface $nostoProductService,
+        Logger $logger
     ) {
         $this->nostoProductService = $nostoProductService;
+        $this->logger = $logger;
     }
 
     /**
@@ -66,7 +73,11 @@ class SanitizingProductService implements ProductServiceInterface
             $store
         );
         if ($nostoProduct !== null) {
-            return $nostoProduct->sanitize();
+            try {
+                return $nostoProduct->sanitize();
+            } catch (\Exception $e) {
+                $this->logger->exception($e);
+            }
         }
         return null;
     }

--- a/Model/Service/Sync/Upsert/SyncService.php
+++ b/Model/Service/Sync/Upsert/SyncService.php
@@ -140,11 +140,15 @@ class SyncService extends AbstractService
                     sprintf('Upserting product "%s"', $productIndex->getProductId()),
                     ['store' => $productIndex->getStoreId()]
                 );
-                $op->addProduct(
-                    $this->productSerializer->fromString(
-                        $productData
-                    )
-                );
+                try {
+                    $op->addProduct(
+                        $this->productSerializer->fromString(
+                            $productData
+                        )
+                    );
+                } catch (\Exception $e) {
+                    $this->getLogger()->exception($e);
+                }
             }
             try {
                 $this->getLogger()->debug('Upserting batch');

--- a/Setup/Core.php
+++ b/Setup/Core.php
@@ -46,7 +46,7 @@ use Nosto\Tagging\Model\ResourceModel\Product\Cache as CacheResource;
 
 abstract class Core
 {
-    const PRODUCT_DATA_MAX_LENGHT = '32M';
+    const PRODUCT_DATA_MAX_LENGTH = '32M';
 
     /**
      * Creates a table for mapping Nosto customer to Magento's cart & orders

--- a/Setup/Core.php
+++ b/Setup/Core.php
@@ -46,6 +46,8 @@ use Nosto\Tagging\Model\ResourceModel\Product\Cache as CacheResource;
 
 abstract class Core
 {
+    const PRODUCT_DATA_MAX_LENGHT = '32M';
+
     /**
      * Creates a table for mapping Nosto customer to Magento's cart & orders
      *
@@ -193,7 +195,7 @@ abstract class Core
             ->addColumn(
                 ProductCacheInterface::PRODUCT_DATA,
                 Table::TYPE_TEXT,
-                null,
+                self::PRODUCT_DATA_MAX_LENGHT,
                 [
                     'nullable' => true,
                     'unsigned' => true,

--- a/Setup/Core.php
+++ b/Setup/Core.php
@@ -195,7 +195,7 @@ abstract class Core
             ->addColumn(
                 ProductCacheInterface::PRODUCT_DATA,
                 Table::TYPE_TEXT,
-                self::PRODUCT_DATA_MAX_LENGHT,
+                self::PRODUCT_DATA_MAX_LENGTH,
                 [
                     'nullable' => true,
                     'unsigned' => true,

--- a/Setup/CoreData.php
+++ b/Setup/CoreData.php
@@ -195,4 +195,12 @@ abstract class CoreData
             }
         }
     }
+
+    /**
+     * @return Logger
+     */
+    public function getLogger()
+    {
+        return $this->logger;
+    }
 }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -179,7 +179,7 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
                         $nullableIds[] = $cachedProduct->getId();
                     }
                 }
-                if (count($canBeConverted) > 0) {
+                if (!empty($cachedProduct)) {
                     $convertSql = sprintf(
                         'UPDATE %s SET %s = TO_BASE64(%s) WHERE %s IN(%s)',
                         CacheResource::TABLE_NAME,
@@ -188,9 +188,9 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
                         Cache::ID,
                         implode(',', $canBeConverted)
                     );
-                    $connection->query($convertSql);
+                    $connection->query($convertSql); // @codingStandardsIgnoreLine
                 }
-                if (count($nullableIds) > 0) {
+                if (!empty($nullableIds)) {
                     $setNullSql = sprintf(
                         'UPDATE %s SET %s = NULL, %s=1 WHERE %s IN(%s)',
                         CacheResource::TABLE_NAME,
@@ -199,7 +199,7 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
                         Cache::ID,
                         implode(',', $nullableIds)
                     );
-                    $connection->query($setNullSql);
+                    $connection->query($setNullSql);  // @codingStandardsIgnoreLine
                 }
             }
         } catch (\Exception $e) {

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -41,15 +41,21 @@ use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerC
 use Magento\Customer\Setup\CustomerSetupFactory;
 use Magento\Eav\Model\Entity\Attribute\SetFactory as AttributeSetFactory;
 use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\UpgradeDataInterface;
 use Magento\Store\Model\ScopeInterface;
 use Nosto\NostoException;
+use Nosto\Object\Product\Product;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Url as NostoHelperUrl;
 use Nosto\Tagging\Logger\Logger;
+use Nosto\Tagging\Model\Product\Cache;
+use Nosto\Tagging\Model\ResourceModel\Product\Cache as CacheResource;
+use Nosto\Tagging\Model\ResourceModel\Product\Cache\CacheCollectionFactory;
+use Nosto\Tagging\Util\PagingIterator;
 use Zend_Validate_Exception;
 
 class UpgradeData extends CoreData implements UpgradeDataInterface
@@ -63,6 +69,9 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
     /** @var WriterInterface */
     private $config;
 
+    /** @var CacheCollectionFactory */
+    private $cacheCollectionFactory;
+
     /**
      * UpgradeData constructor.
      * @param NostoHelperAccount $nostoHelperAccount
@@ -72,6 +81,7 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
      * @param AttributeSetFactory $attributeSetFactory
      * @param CustomerCollectionFactory $customerCollectionFactory
      * @param CustomerResource $customerResource
+     * @param CacheCollectionFactory $cacheCollectionFactory
      * @param Logger $logger
      */
     public function __construct(
@@ -82,11 +92,13 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
         AttributeSetFactory $attributeSetFactory,
         CustomerCollectionFactory $customerCollectionFactory,
         CustomerResource $customerResource,
+        CacheCollectionFactory $cacheCollectionFactory,
         Logger $logger
     ) {
         $this->nostoHelperAccount = $nostoHelperAccount;
         $this->nostoHelperUrl = $nostoHelperUrl;
         $this->config = $appConfig;
+        $this->cacheCollectionFactory = $cacheCollectionFactory;
         parent::__construct(
             $customerSetupFactory,
             $attributeSetFactory,
@@ -118,6 +130,9 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
         if (version_compare($fromVersion, '3.10.5', '<=')) {
             $this->populateCustomerReference();
         }
+        if (version_compare($fromVersion, '4.0.3', '<=')) {
+            $this->convertProductDataToBase64($setup->getConnection());
+        }
     }
 
     /**
@@ -139,6 +154,56 @@ class UpgradeData extends CoreData implements UpgradeDataInterface
                     $store->getId()
                 );
             }
+        }
+    }
+
+    /**
+     * Converts serialized product data to base64 encoded data to avoid charset & collation problems
+     *
+     * @param AdapterInterface $connection
+     */
+    public function convertProductDataToBase64(AdapterInterface $connection)
+    {
+        try {
+            $cachedProductCollection = $this->cacheCollectionFactory->create()->setPageSize(1000);
+            $iterator = new PagingIterator($cachedProductCollection);
+            foreach ($iterator as $page) {
+                $canBeConverted = [];
+                $nullableIds = [];
+                /* @var Cache $cachedProduct */
+                foreach ($page as $cachedProduct) {
+                    try {
+                        unserialize($cachedProduct->getProductData(), [Product::class]); // @codingStandardsIgnoreLine
+                        $canBeConverted[] = $cachedProduct->getId();
+                    } catch (\Exception $e) {
+                        $nullableIds[] = $cachedProduct->getId();
+                    }
+                }
+                if (count($canBeConverted) > 0) {
+                    $convertSql = sprintf(
+                        'UPDATE %s SET %s = TO_BASE64(%s) WHERE %s IN(%s)',
+                        CacheResource::TABLE_NAME,
+                        Cache::PRODUCT_DATA,
+                        Cache::PRODUCT_DATA,
+                        Cache::ID,
+                        implode(',', $canBeConverted)
+                    );
+                    $connection->query($convertSql);
+                }
+                if (count($nullableIds) > 0) {
+                    $setNullSql = sprintf(
+                        'UPDATE %s SET %s = NULL, %s=1 WHERE %s IN(%s)',
+                        CacheResource::TABLE_NAME,
+                        Cache::PRODUCT_DATA,
+                        Cache::IS_DIRTY,
+                        Cache::ID,
+                        implode(',', $nullableIds)
+                    );
+                    $connection->query($setNullSql);
+                }
+            }
+        } catch (\Exception $e) {
+            $this->getLogger()->exception($e);
         }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -97,7 +97,7 @@ class UpgradeSchema extends Core implements UpgradeSchemaInterface
             Cache::PRODUCT_DATA,
             [
                 'type' => Table::TYPE_TEXT,
-                'length' => self::PRODUCT_DATA_MAX_LENGHT,
+                'length' => self::PRODUCT_DATA_MAX_LENGTH,
                 'nullable' => true,
                 'comment' => 'Product data'
             ]

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -41,7 +41,9 @@ use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
 use Nosto\Tagging\Api\Data\CustomerInterface;
+use Nosto\Tagging\Model\Product\Cache;
 use Nosto\Tagging\Model\ResourceModel\Customer;
+use Nosto\Tagging\Model\ResourceModel\Product\Cache as CacheResource;
 
 class UpgradeSchema extends Core implements UpgradeSchemaInterface
 {
@@ -53,21 +55,52 @@ class UpgradeSchema extends Core implements UpgradeSchemaInterface
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
         $setup->startSetup();
-        $connection = $setup->getConnection();
         $fromVersion = $context->getVersion();
         if (version_compare($fromVersion, '2.1.0', '<')) {
-            $connection->addColumn(
-                $setup->getTable(Customer::TABLE_NAME),
-                CustomerInterface::RESTORE_CART_HASH,
-                [
-                    'type' => Table::TYPE_TEXT,
-                    'nullable' => true,
-                    'comment' => 'Restore cart hash',
-                    'length' => CustomerInterface::NOSTO_TAGGING_RESTORE_CART_ATTRIBUTE_LENGTH
-                ]
-            );
+            $this->addRestoreCartHash($setup);
+        }
+        if (version_compare($fromVersion, '4.0.3', '<=')) {
+            $this->productCacheDataToLongtext($setup);
         }
 
         $setup->endSetup();
+    }
+
+    /**
+     * Adds the restore cart hash to Nosto customer table
+     *
+     * @param SchemaSetupInterface $setup
+     */
+    private function addRestoreCartHash(SchemaSetupInterface $setup)
+    {
+        $setup->getConnection()->addColumn(
+            $setup->getTable(Customer::TABLE_NAME),
+            CustomerInterface::RESTORE_CART_HASH,
+            [
+                'type' => Table::TYPE_TEXT,
+                'nullable' => true,
+                'comment' => 'Restore cart hash',
+                'length' => CustomerInterface::NOSTO_TAGGING_RESTORE_CART_ATTRIBUTE_LENGTH
+            ]
+        );
+    }
+
+    /**
+     * Changes the product_data column to be longtext for Nosto product cache
+     *
+     * @param SchemaSetupInterface $setup
+     */
+    private function productCacheDataToLongtext(SchemaSetupInterface $setup)
+    {
+        $setup->getConnection()->modifyColumn(
+            $setup->getTable(CacheResource::TABLE_NAME),
+            Cache::PRODUCT_DATA,
+            [
+                'type' => Table::TYPE_TEXT,
+                'length' => self::PRODUCT_DATA_MAX_LENGHT,
+                'nullable' => true,
+                'comment' => 'Product data'
+            ]
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.3"/>
+    <module name="Nosto_Tagging" setup_version="4.0.4"/>
 </config>


### PR DESCRIPTION
## Description
* Store cached Nosto product data as a base64 encoded string in database to avoid problems with character sets and collation
* Alter the type of cached product to be longtext to allow saving large product data sets

## Related Issue
#652 

## Motivation and Context
* Serialization might fail due to non utf8 charset and collation
* If serialized data is truncated it can not be deserialized   

## How Has This Been Tested?
Tested locally by running upgrades & indexers multiple times.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
