### PR TITLE
Hotfix/4.0.5 - Add createProductCacheTable call to UpgradeSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 4.0.5
+* Fix an issue where product cache table was not created during upgrade
+
 # 4.0.4
 * Store cached Nosto product data as a base64 encoded string in database to avoid problems with character sets and collations
 * Alter the type of cached product to be longtext to allow saving large product data sets

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -44,6 +44,7 @@ use Nosto\Tagging\Api\Data\CustomerInterface;
 use Nosto\Tagging\Model\Product\Cache;
 use Nosto\Tagging\Model\ResourceModel\Customer;
 use Nosto\Tagging\Model\ResourceModel\Product\Cache as CacheResource;
+use Zend_Db_Exception;
 
 class UpgradeSchema extends Core implements UpgradeSchemaInterface
 {
@@ -51,6 +52,7 @@ class UpgradeSchema extends Core implements UpgradeSchemaInterface
 
     /**
      * {@inheritdoc}
+     * @throws Zend_Db_Exception
      */
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -62,7 +64,9 @@ class UpgradeSchema extends Core implements UpgradeSchemaInterface
         if (version_compare($fromVersion, '4.0.3', '<=')) {
             $this->productCacheDataToLongtext($setup);
         }
-
+        if (version_compare($fromVersion, '4.0.4', '<=')) {
+            $this->createProductCacheTable($setup);
+        }
         $setup->endSetup();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.4"/>
+    <module name="Nosto_Tagging" setup_version="4.0.5"/>
 </config>


### PR DESCRIPTION
## Description
Add createProductCacheTable call to UpgradeSchema

## Related Issue
Fixes #656 

## Motivation and Context
Lack of creating table createProductCacheTable when upgrading can cause trouble using the indexer.

## How Has This Been Tested?
- Locally drop the table and run `bin/magento setup:upgrade`

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
