### PR TITLE
Fix issue with non generated proxy classes during di compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 4.0.6
+* Fix issue with non-generated proxy classes during di compilation 
+
 # 4.0.5
 * Fix an issue where product cache table was not created during upgrade
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.6-rc1",
+  "version": "4.0.6",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.6",
+  "version": "4.0.6-rc1",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -85,7 +85,7 @@
     </type>
     <type name="Nosto\Tagging\Console\Command\NostoRebuildInvalidProductData">
         <arguments>
-            <argument name="productDataCron" xsi:type="object">Nosto\Tagging\Cron\ProductDataCron\Proxy</argument>
+            <argument name="productDataCron" xsi:type="object">Nosto\Tagging\Cron\ProductDataCron</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Observer\Order\Save">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -83,9 +83,14 @@
             </argument>
         </arguments>
     </type>
+    <type name="Nosto\Tagging\Cron\ProductDataCron">
+        <arguments>
+            <argument name="batchSize" xsi:type="number">1000</argument>
+        </arguments>
+    </type>
     <type name="Nosto\Tagging\Console\Command\NostoRebuildInvalidProductData">
         <arguments>
-            <argument name="productDataCron" xsi:type="object">Nosto\Tagging\Cron\ProductDataCron</argument>
+            <argument name="productDataCron" xsi:type="object">Nosto\Tagging\Cron\ProductDataCron\Proxy</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Observer\Order\Save">
@@ -221,23 +226,6 @@
         <arguments>
             <argument name="intervalHours" xsi:type="number">4</argument>
             <argument name="productLimit" xsi:type="number">1000</argument>
-        </arguments>
-    </type>
-    <type name="Nosto\Tagging\Cron\ProductDataCron">
-        <arguments>
-            <argument name="nostoAccountHelper" xsi:type="object">
-                Nosto\Tagging\Helper\Account\Proxy
-            </argument>
-            <argument name="nostoDataHelper" xsi:type="object">
-                Nosto\Tagging\Helper\Data\Proxy
-            </argument>
-            <argument name="cacheRepository" xsi:type="object">
-                Nosto\Tagging\Model\Product\Cache\CacheRepository\Proxy
-            </argument>
-            <argument name="cacheService" xsi:type="object">
-                Nosto\Tagging\Model\Service\Cache\CacheService\Proxy
-            </argument>
-            <argument name="batchSize" xsi:type="number">1000</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Model\Service\Sync\Upsert\AsyncBulkPublisher">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.6-rc1"/>
+    <module name="Nosto_Tagging" setup_version="4.0.6"/>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.6"/>
+    <module name="Nosto_Tagging" setup_version="4.0.6-rc1"/>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.5"/>
+    <module name="Nosto_Tagging" setup_version="4.0.6"/>
 </config>


### PR DESCRIPTION
## Description
Remove proxy definitions for `ProductDataCron` as the those are not generated during `setup:di:compile`.

## Related Issue
#662 

## Motivation and Context
The cron command throws an error read-only filesystem (such as Magento cloud) as the proxy class cannot be created on the fly. 

## How Has This Been Tested?
Tested locally and in our test cloud.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
