### PR TITLE
Changed UrlInterface to allow urlBuilder to build the right adminhtml…

### DIFF
--- a/Helper/Account.php
+++ b/Helper/Account.php
@@ -40,6 +40,7 @@ use Exception;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
+use Magento\Backend\Model\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
@@ -87,12 +88,14 @@ class Account extends AbstractHelper
      * @param WriterInterface $appConfig
      * @param Scope $nostoHelperScope
      * @param Url $nostoHelperUrl
+     * @param UrlInterface $urlInterface
      */
     public function __construct(
         Context $context,
         WriterInterface $appConfig,
         NostoHelperScope $nostoHelperScope,
-        NostoHelperUrl $nostoHelperUrl
+        NostoHelperUrl $nostoHelperUrl,
+        UrlInterface $urlInterface
     ) {
         parent::__construct($context);
 
@@ -101,7 +104,7 @@ class Account extends AbstractHelper
         $this->logger = $context->getLogger();
         $this->nostoHelperScope = $nostoHelperScope;
         $this->nostoHelperUrl = $nostoHelperUrl;
-        $this->urlBuilder = $context->getUrlBuilder();
+        $this->urlBuilder = $urlInterface;
     }
 
     /**


### PR DESCRIPTION
… path.

The helper is creating a public/store front URL on backend and when you try to reset your account your are redirected to the store front and you get a 404.

## Description
Changed the urlBuilder instance.

## Related Issue

https://github.com/Nosto/nosto-magento2/issues/667

## Motivation and Context
You can't reset the account settings.

## How Has This Been Tested?

1. The URL that you can see at the Backend notification message looks correct.
2. Once you click the "Reset Nosto settings" you are redirected to Nosto - Account Settgins page.

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
