### PR TITLE
Add google category tagging feature flag and to product builder

### DIFF
--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Run Phan analysis
       id: phan-analysis
       run: |
-        ./vendor/bin/phan --config-file=phan.php --output-mode=checkstyle --output=chkphan.xml --processes=4
+        ./vendor/bin/phan --config-file=phan.php --output-mode=checkstyle --output=chkphan.xml
       continue-on-error: true
 
     - name: Archive static analysis results

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -85,6 +85,11 @@ class Data extends AbstractHelper
     const XML_PATH_GTIN_ATTRIBUTE = 'nosto/optional/gtin';
 
     /**
+     * Path to the configuration object that store's the google_category attribute
+     */
+    const XML_PATH_GOOGLE_CATEGORY_ATTRIBUTE = 'nosto/optional/google_category';
+
+    /**
      * Path to the configuration object that stores the preference to tag variation data
      */
     const XML_PATH_VARIATION_TAGGING = 'nosto/flags/variation_tagging';
@@ -304,6 +309,17 @@ class Data extends AbstractHelper
     public function getGtinAttribute(StoreInterface $store = null)
     {
         return $this->getStoreConfig(self::XML_PATH_GTIN_ATTRIBUTE, $store);
+    }
+
+    /**
+     * Returns the value of the selected google category attribute from the configuration table
+     *
+     * @param StoreInterface|null $store the store model or null.
+     * @return string the configuration value
+     */
+    public function getGoogleCategoryAttribute(StoreInterface $store = null)
+    {
+        return $this->getStoreConfig(self::XML_PATH_GOOGLE_CATEGORY_ATTRIBUTE, $store);
     }
 
     /**

--- a/Model/Config/Source/GoogleCategory.php
+++ b/Model/Config/Source/GoogleCategory.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\Config\Source;
+
+use Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection;
+
+/**
+ * Option array class to generate a list of selectable options that allows the merchant to choose
+ * any attribute for his google category tag.
+ */
+class GoogleCategory extends Selector
+{
+    /**
+     * @param Collection $collection
+     * @suppress PhanTypeMismatchArgument
+     */
+    public function filterCollection(Collection $collection)
+    {
+        /** @noinspection PhpParamsInspection */
+        $collection->setFrontendInputTypeFilter(['text', 'textarea']);
+    }
+
+    public function isNullable()
+    {
+        return true;
+    }
+}

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -272,6 +272,15 @@ class Builder
                     )
                 );
             }
+            $googleCategoryAttr = $this->getDataHelper()->getGoogleCategoryAttribute($store);
+            if ($product->hasData($googleCategoryAttr)) {
+                $nostoProduct->setGoogleCategory(
+                    $this->attributeService->getAttributeValueByAttributeCode(
+                        $product,
+                        $googleCategoryAttr
+                    )
+                );
+            }
             // When using customer group price variations, set the variations
             if ($this->getDataHelper()->isPricingVariationEnabled($store)
                 && $this->getDataHelper()->isMultiCurrencyDisabled($store)

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -102,6 +102,14 @@
                     </comment>
                     <source_model>Nosto\Tagging\Model\Config\Source\Gtin</source_model>
                 </field>
+                <field id="google_category" translate="label comment" type="select" sortOrder="40"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Google Category</label>
+                    <comment>Select the attribute that you would like to use as your Google Category
+                        attribute.
+                    </comment>
+                    <source_model>Nosto\Tagging\Model\Config\Source\GoogleCategory</source_model>
+                </field>
             </group>
             <group id="flags" translate="label" type="text" sortOrder="30" showInDefault="1"
                    showInWebsite="1" showInStore="1">


### PR DESCRIPTION
## Description
Add a selector to map google category attribute to product tagging.

## Related Issue
Closes #676

## Motivation and Context
N/A
## How Has This Been Tested
Add an attribute and map to the new selector, reindex the product and should shop up on Nosto's backend.

## Documentation:
Check Magento docs about how those are mapped into google categories.
https://docs.magento.com/user-guide/sales-channels/google-ads/attribute-mapping.html

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities

## Screenshots
![image](https://user-images.githubusercontent.com/2778820/82662366-6717c700-9c36-11ea-9933-96552af615e6.png)
![image](https://user-images.githubusercontent.com/2778820/82662404-77c83d00-9c36-11ea-80d7-f12dc4b849e6.png)
