### PR TITLE
Add null guard after product cache rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 4.0.8
+* Add null guard for caching product service in case the product data building fails for dirty product
+
 # 4.0.7
 * Handle empty / invalid product cache entries and possible failures in product data building gracefully
 

--- a/Model/Service/Product/CachingProductService.php
+++ b/Model/Service/Product/CachingProductService.php
@@ -110,6 +110,16 @@ class CachingProductService implements ProductServiceInterface
             //If it is dirty rebuild the product data
             if ($cachedProduct->getIsDirty()) {
                 $cachedProduct = $this->nostoCacheService->rebuildDirtyProduct($cachedProduct);
+                if ($cachedProduct == null) {
+                    $this->nostoLogger->debug(
+                        sprintf(
+                            'Unable to rebuild dirty cache entry for product #%s for store %s',
+                            $product->getId(),
+                            $store->getCode()
+                        )
+                    );
+                    return null;
+                }
             }
             //Check that we actually got serializable data
             $productData = $cachedProduct->getProductData();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "require-dev": {
     "php": ">=7.1.0",
     "phan/phan": "0.8.8",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="4.0.7"/>
+    <module name="Nosto_Tagging" setup_version="4.0.8"/>
 </config>


### PR DESCRIPTION
## Description
Add a null guard for dirty product cache rebuild.

## Related Issue
#677 

## Motivation and Context
Execution might throw an uncaught exception if rebuilding the cached product data fails.  

## How Has This Been Tested?
Tested locally by trying to build non-buildable producrts. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
