### PR TITLE
Removed obsolete trigger for catalog_product_entity_media_gallery

### DIFF
--- a/etc/mview.xml
+++ b/etc/mview.xml
@@ -42,7 +42,6 @@
             <table name="catalog_product_entity_decimal" entity_column="entity_id" />
             <table name="catalog_product_entity_gallery" entity_column="entity_id" />
             <table name="catalog_product_entity_int" entity_column="entity_id" />
-            <table name="catalog_product_entity_media_gallery" entity_column="value_id" />
             <table name="catalog_product_entity_media_gallery_value" entity_column="entity_id" />
             <table name="catalog_product_entity_text" entity_column="entity_id" />
             <table name="catalog_product_entity_tier_price" entity_column="entity_id" />


### PR DESCRIPTION
## Description
Removed mview trigger catalog_product_entity_media_gallery. 

## Motivation and Context
Sometimes We get reports from clients about stuck on re-index products from Magento to Nosto. All indices are "On Schedule" mode. After research We found reason - It's related with trigger to "catalog_product_entity_media_gallery" table and value_id column. If Images are updated often on huge catalog you can get next case  in nosto_product_sync_cl table:
version_id entity_id,
14 17500,
15 17500,
16 17500,
17 17500,
18 17500,
19 17500,
20 17500,
21 17500,
22 17500,
23 1193238, (it's value_id and it blocks updates)
24 17500,
25 17500

After checking in Magento code, I found difference - This trigger was added in Magento 2.1 and It was removed in Magento 2.2.0:
Magento 2.1: https://github.com/magento/magento2/blob/2.1/app/code/Magento/Catalog/etc/mview.xml
Magento 2.2 (since 2.2.0-RC1.1) : magento/magento2@9fe3b8a#diff-b82ecede1475a66d3135943308251166
Magento 2.2.0 : https://github.com/magento/magento2/blob/2.2.0/app/code/Magento/Catalog/etc/mview.xml#L32

