### PR TITLE
Hotfix/5.0.2 - Fix override custom tags by default tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 5.0.2
+* Fix an issue where custom tags (tag1) were overridden by default tags
+  
 # 5.0.1
 * Fix an issue with configurable product prices being zero in Nosto product data when taxes are included in display prices
 

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -225,7 +225,6 @@ class Builder
             }
             $nostoProduct->setCustomFields($this->getCustomFieldsWithAttributes($product, $store));
             // Update customised Tag1, Tag2 and Tag3
-            $this->amendAttributeTags($product, $nostoProduct, $store);
             if ($this->getDataHelper()->isAltimgTaggingEnabled($store)) {
                 $nostoProduct->setAlternateImageUrls($this->buildAlternativeImages($product, $store));
             }
@@ -245,6 +244,7 @@ class Builder
             if (($tags = $this->buildDefaultTags($product, $store)) !== []) {
                 $nostoProduct->setTag1($tags);
             }
+            $this->amendAttributeTags($product, $nostoProduct, $store);
             $brandAttribute = $this->getDataHelper()->getBrandAttribute($store);
             if ($product->hasData($brandAttribute)) {
                 $nostoProduct->setBrand(

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "require-dev": {
     "php": ">=7.1.0",
     "phpmd/phpmd": "^2.5",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="5.0.1"/>
+    <module name="Nosto_Tagging" setup_version="5.0.2"/>
 </config>


### PR DESCRIPTION
## Description
On the product builder, `amendAttributeTags();` was being called before `$nostoProduct->setTag1();`.
Internally, `amendAttributeTags();`uses `addTag1()`, which is overriden by the set called right after

## Related Issue
Closes #697 

## How Has This Been Tested?
Locally building product and adding custom tags to tag1

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
