### PR TITLE
Fix fetching price for configurable product from wrong store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 5.0.4
+* Fix an issue with incorrect prices when different base currencies are used in websites and taxes are included in display prices   
+
 # 5.0.3
 * Bump the PHP SDK version to be compatible with Nosto CMP module (no functional changes)
 

--- a/Helper/Price.php
+++ b/Helper/Price.php
@@ -413,10 +413,10 @@ class Price extends AbstractHelper
                     )
                 );
             }
-            $skuResult = $this->nostoProductRepository->getByIds([$minSku[self::KEY_SKU_PRODUCT_ID]]);
-            $skuProducts = $skuResult->getItems();
-            $skuProduct = reset($skuProducts);
-
+            $skuProduct = $this->nostoProductRepository->reloadProduct(
+                $minSku[self::KEY_SKU_PRODUCT_ID],
+                $store->getId()
+            );
             if ($skuProduct instanceof Product) {
                 $price = $this->getProductPrice($skuProduct, $store, true, $finalPrice);
             }

--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -264,4 +264,21 @@ class Repository
         );
         return $this->skuResource->getSkuPricesByIds($store->getWebsite(), $inStockProductsByIds);
     }
+
+    /**
+     * Loads (or reloads) Product object
+     * @param int $productId
+     * @param int $storeId
+     * @return ProductInterface|Product
+     * @throws NoSuchEntityException
+     */
+    public function reloadProduct($productId, $storeId)
+    {
+        return $this->productRepository->getById(
+            $productId,
+            false,
+            $storeId,
+            true
+        );
+    }
 }

--- a/Model/Service/Product/DefaultProductService.php
+++ b/Model/Service/Product/DefaultProductService.php
@@ -39,7 +39,6 @@ namespace Nosto\Tagging\Model\Service\Product;
 use Exception;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ProductRepository;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\Store;
 use Nosto\Exception\FilteredProductException;

--- a/Model/Service/Product/DefaultProductService.php
+++ b/Model/Service/Product/DefaultProductService.php
@@ -40,7 +40,6 @@ use Exception;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductRepository;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\Store;
 use Nosto\Exception\FilteredProductException;
@@ -59,7 +58,7 @@ class DefaultProductService implements ProductServiceInterface
     /** @var NostoLogger */
     private $logger;
 
-    /** @var ProductRepository */
+    /** @var NostoProductRepository */
     private $nostoProductRepository;
 
     /**

--- a/Model/Service/Product/DefaultProductService.php
+++ b/Model/Service/Product/DefaultProductService.php
@@ -39,6 +39,7 @@ namespace Nosto\Tagging\Model\Service\Product;
 use Exception;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ProductRepository;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\Store;
@@ -47,7 +48,7 @@ use Nosto\Exception\NonBuildableProductException;
 use Nosto\Model\Product\Product as NostoProduct;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Product\Builder as NostoProductBuilder;
-use Magento\Catalog\Model\ProductRepository;
+use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
 
 class DefaultProductService implements ProductServiceInterface
 {
@@ -59,21 +60,21 @@ class DefaultProductService implements ProductServiceInterface
     private $logger;
 
     /** @var ProductRepository */
-    private $productRepository;
+    private $nostoProductRepository;
 
     /**
      * DefaultProductService constructor.
      * @param NostoProductBuilder $nostoProductBuilder
-     * @param ProductRepository $productRepository
+     * @param NostoProductRepository $nostoProductRepository
      * @param NostoLogger $logger
      */
     public function __construct(
         NostoProductBuilder $nostoProductBuilder,
-        ProductRepository $productRepository,
+        NostoProductRepository $nostoProductRepository,
         NostoLogger $logger
     ) {
         $this->nostoProductBuilder = $nostoProductBuilder;
-        $this->productRepository = $productRepository;
+        $this->nostoProductRepository = $nostoProductRepository;
         $this->logger = $logger;
     }
 
@@ -90,7 +91,10 @@ class DefaultProductService implements ProductServiceInterface
         /** @var Store $store */
         try {
             return $this->nostoProductBuilder->build(
-                $this->reloadProduct($product, $store),
+                $this->nostoProductRepository->reloadProduct(
+                    $product->getId(),
+                    $store->getId()
+                ),
                 $store
             );
         } catch (NonBuildableProductException $e) {
@@ -105,22 +109,5 @@ class DefaultProductService implements ProductServiceInterface
             );
             return null;
         }
-    }
-
-    /**
-     * Loads (or reloads) Product object
-     * @param ProductInterface $product
-     * @param StoreInterface $store
-     * @return ProductInterface|Product
-     * @throws NoSuchEntityException
-     */
-    private function reloadProduct(ProductInterface $product, StoreInterface $store)
-    {
-        return $this->productRepository->getById(
-            $product->getId(),
-            false,
-            $store->getId(),
-            true
-        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "require-dev": {
     "php": ">=7.1.0",
     "phpmd/phpmd": "^2.5",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="5.0.3"/>
+    <module name="Nosto_Tagging" setup_version="5.0.4"/>
 </config>


### PR DESCRIPTION
## Description
Change the product data reloading to use correct store / website. 

## Related Issue
Closes #702 
 
## Motivation and Context
Wrong prices are sent to Nosto for configurable products when multiple base currencies are used and product prices are configured to be displayed including taxes.

## How Has This Been Tested?
Tested locally with multiple websites and different base currencies. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
