### PR TITLE
Allow account to be created with the same email of Magento admin

### DIFF
--- a/Controller/Adminhtml/Account/Create.php
+++ b/Controller/Adminhtml/Account/Create.php
@@ -143,52 +143,49 @@ class Create extends Base
 
                 $emailAddress = $this->_request->getParam('email');
                 $accountOwner = $this->nostoOwnerBuilder->build();
-                if ($accountOwner->getEmail() !== $emailAddress) {
-                    if (Zend_Validate::is($emailAddress, 'EmailAddress')) {
-                        $accountOwner->setFirstName(null);
-                        $accountOwner->setLastName(null);
-                        $accountOwner->setEmail($emailAddress);
-                        /** @var array $signupDetails */
-                        $signupParams = $this->nostoSignupBuilder->build(
-                            $store,
-                            $accountOwner,
-                            $signupDetails
+                if (Zend_Validate::is($emailAddress, 'EmailAddress')) {
+                    $accountOwner->setFirstName(null);
+                    $accountOwner->setLastName(null);
+                    $accountOwner->setEmail($emailAddress);
+                    /** @var array $signupDetails */
+                    $signupParams = $this->nostoSignupBuilder->build(
+                        $store,
+                        $accountOwner,
+                        $signupDetails
+                    );
+                    $operation = new AccountSignup($signupParams);
+                    $account = $operation->create();
+
+                    if ($this->nostoHelperAccount->saveAccount($account, $store)) {
+                        $response['success'] = true;
+                        $response['redirect_url'] = IframeHelper::getUrl(
+                            $this->nostoIframeMetaBuilder->build($store),
+                            $account,
+                            $this->nostoCurrentUserBuilder->build(),
+                            [
+                                'message_type' => Nosto::TYPE_SUCCESS,
+                                'message_code' => Nosto::CODE_ACCOUNT_CREATE,
+                            ]
                         );
-                        $operation = new AccountSignup($signupParams);
-                        $account = $operation->create();
 
-                        if ($this->nostoHelperAccount->saveAccount($account, $store)) {
-                            $response['success'] = true;
-                            $response['redirect_url'] = IframeHelper::getUrl(
-                                $this->nostoIframeMetaBuilder->build($store),
-                                $account,
-                                $this->nostoCurrentUserBuilder->build(),
-                                [
-                                    'message_type' => Nosto::TYPE_SUCCESS,
-                                    'message_code' => Nosto::CODE_ACCOUNT_CREATE,
-                                ]
-                            );
-
-                            // Note that we will send the exchange rates even if the multi currency
-                            // is not set. This is mostly for debugging purposes.
-                            if ($this->nostoCurrencyHelper->getCurrencyCount($store) > 1) {
-                                try {
-                                    $this->nostoRatesService->update($store);
-                                } catch (Exception $e) {
-                                    $this->logger->exception($e);
-                                }
+                        // Note that we will send the exchange rates even if the multi currency
+                        // is not set. This is mostly for debugging purposes.
+                        if ($this->nostoCurrencyHelper->getCurrencyCount($store) > 1) {
+                            try {
+                                $this->nostoRatesService->update($store);
+                            } catch (Exception $e) {
+                                $this->logger->exception($e);
                             }
-
-                            //invalidate page cache and layout cache
-                            $this->nostoHelperCache->invalidatePageCache();
-                            $this->nostoHelperCache->invalidateLayoutCache();
                         }
-                    } else {
-                        $this->logger->exception(new NostoException('Invalid email address ' . $emailAddress));
-                        $messageText = 'Invalid email address ' . $emailAddress;
+
+                        //invalidate page cache and layout cache
+                        $this->nostoHelperCache->invalidatePageCache();
+                        $this->nostoHelperCache->invalidateLayoutCache();
                     }
+                } else {
+                    $this->logger->exception(new NostoException('Invalid email address ' . $emailAddress));
+                    $messageText = 'Invalid email address ' . $emailAddress;
                 }
-                
             } catch (NostoException $e) {
                 $this->logger->exception($e);
                 $messageText = $e->getMessage();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow the user to create a nosto account by using the same account as the admin. 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
