### PR TITLE
ADS-2822: Set availability value to invisible for disabled products

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -134,6 +134,11 @@ class Data extends AbstractHelper
      */
     const XML_PATH_INDEXER_MEMORY = 'nosto/flags/indexer_memory';
 
+    /**
+     * Path to the configuration object that stores the preference for indexing disabled products
+     */
+    const XML_PATH_INDEX_DISABLED_PRODUCTS = 'nosto/flags/indexer_disabled_products';
+
     /*
      * Path to the configuration object for tagging the date a product has beed added to Magento's catalog
      */
@@ -442,6 +447,17 @@ class Data extends AbstractHelper
     public function getIndexerMemory(StoreInterface $store = null)
     {
         return $this->getStoreConfig(self::XML_PATH_INDEXER_MEMORY, $store);
+    }
+
+    /**
+     * Returns maximum percentage of PHP available memory that indexer should use
+     *
+     * @param StoreInterface|null $store the store model or null.
+     * @return bool the configuration value
+     */
+    public function canIndexDisabledProducts(StoreInterface $store = null)
+    {
+        return $this->getStoreConfig(self::XML_PATH_INDEX_DISABLED_PRODUCTS, $store);
     }
 
     /**

--- a/Model/Indexer/QueueIndexer.php
+++ b/Model/Indexer/QueueIndexer.php
@@ -184,7 +184,7 @@ class QueueIndexer extends AbstractIndexer
         if (!empty($ids)) {
             $this->productCollectionBuilder->withIds($ids);
         } else {
-            $this->productCollectionBuilder->withDefaultVisibility();
+            $this->productCollectionBuilder->withDefaultVisibility($store);
         }
         return $this->productCollectionBuilder->build();
     }

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -395,6 +395,7 @@ class Builder
         $availability = ProductInterface::OUT_OF_STOCK;
         $isInStock = $this->isInStock($product, $store);
         if (!$product->isVisibleInSiteVisibility()
+            || !$product->isAvailable()
             || (!$this->isAvailableInStore($product, $store) && $isInStock)
         ) {
             $availability = ProductInterface::INVISIBLE;

--- a/Model/ResourceModel/Magento/Product/Collection.php
+++ b/Model/ResourceModel/Magento/Product/Collection.php
@@ -45,16 +45,21 @@ class Collection extends MagentoProductCollection
     /**
      * @return Collection
      */
-    public function addActiveAndVisibleFilter()
+    public function addVisibleFilter()
     {
         return $this->addAttributeToSelect($this->getIdFieldName())
             ->addAttributeToFilter(
-                'status',
-                ['eq' => Status::STATUS_ENABLED]
-            )->addAttributeToFilter(
                 'visibility',
                 ['neq' => Visibility::VISIBILITY_NOT_VISIBLE]
             );
+    }
+
+    /**
+     * @return Collection
+     */
+    public function addActiveFilter()
+    {
+        return $this->addAttributeToFilter('status', ['eq' => Status::STATUS_ENABLED]);
     }
 
     /**

--- a/Model/ResourceModel/Magento/Product/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Product/CollectionBuilder.php
@@ -109,6 +109,7 @@ class CollectionBuilder
     /**
      * Sets filter for product status based on configuration
      *
+     * @param Store $store
      * @return $this
      */
     public function withConfiguredProductStatus(Store $store)
@@ -193,9 +194,9 @@ class CollectionBuilder
     }
 
     /**
-     * Sets the default visibility. Calls self::withOnlyVisibleInSites()
-     * and self::withOnlyActiveAndVisible()
+     * Sets the default visibility and set active products filter based on configuration
      *
+     * @param Store $store
      * @return CollectionBuilder
      */
     public function withDefaultVisibility(Store $store)

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -199,6 +199,14 @@
                     </comment>
                     <source_model>Nosto\Tagging\Model\Config\Source\Memory</source_model>
                 </field>
+                <field id="indexer_disabled_products" translate="label comment" type="select" sortOrder="120"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Index disabled products</label>
+                    <comment>
+                        <![CDATA[Include disabled products in full reindex. Advised when using Category Merchandising]]>
+                    </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="tag_date_published" translate="label comment" type="select" sortOrder="130"
                        showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Add product published date to tagging</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -56,6 +56,7 @@
                 <low_stock_indication>0</low_stock_indication>
                 <send_customer_data>1</send_customer_data>
                 <indexer_memory>50</indexer_memory>
+                <indexer_disabled_products>0</indexer_disabled_products>
                 <tag_date_published>0</tag_date_published>
                 <track_multi_channel_orders>1</track_multi_channel_orders>
                 <product_caching>0</product_caching>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For products that are disabled in a specific store, the availability value is set to `Invisible`. 
Currently products that are disabled are filtered out from the full-reindex, so a new config flag is added in order to index disabled products. Refactored the Product CollectionBuilder filters to make this possible 

By default the flag is disabled. 
![image](https://user-images.githubusercontent.com/44775916/98819112-2191c500-2435-11eb-9d17-ce85c1225840.png)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
