### PR TITLE
Hotfix 5.1.1 - Check that payment is instance of payment interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+# 5.1.1
+* Check that order payment is instance of payment interface
+
 # 5.1.0
 * Fix addMultipleProductsToCart issue happening in M2 cloud
 

--- a/Model/Order/Builder.php
+++ b/Model/Order/Builder.php
@@ -42,15 +42,15 @@ use Exception;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Phrase;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Item;
-use Magento\Sales\Model\Order\Payment;
 use Magento\SalesRule\Model\RuleFactory as SalesRuleFactory;
-use Nosto\NostoException;
 use Nosto\Model\Cart\LineItem;
 use Nosto\Model\Order\Buyer;
 use Nosto\Model\Order\Order as NostoOrder;
 use Nosto\Model\Order\OrderStatus;
+use Nosto\NostoException;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Order\Buyer\Builder as NostoBuyerBuilder;
 use Nosto\Tagging\Model\Order\Item\Builder as NostoOrderItemBuilder;
@@ -108,7 +108,7 @@ class Builder
                     $nostoOrder->setCreatedAt($orderCreatedDate);
                 }
             }
-            if ($order->getPayment() instanceof Payment) {
+            if ($order->getPayment() instanceof OrderPaymentInterface) {
                 $nostoOrder->setPaymentProvider($order->getPayment()->getMethod());
             } else {
                 throw new NostoException('Order has no payment associated');

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "require-dev": {
     "php": ">=7.1.0",
     "phpmd/phpmd": "^2.5",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="5.1.0"/>
+    <module name="Nosto_Tagging" setup_version="5.1.1"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Check that order payment is instance of payment interface instead of payment class. The implementation would not work if the order payment is overridden by some other modules class that extends the interface

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
