### PR TITLE
Get correct parent product id for grouped products when adding to cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 5.2.3
+* Pass correct product id when adding grouped product to cart
+
 ### 5.2.2
 * Fix bug where disabled parent product ids are added to reindex queue
 

--- a/Model/Cart/Item/Builder.php
+++ b/Model/Cart/Item/Builder.php
@@ -140,7 +140,7 @@ class Builder
         /** @var Item $parentItem */
         $parentItem = $item->getOptionByCode('product_type');
         if ($parentItem !== null) {
-            return $parentItem->getProduct()->getSku();
+            return $parentItem->getProduct()->getId();
         }
         if ($item->getProductType() === Type::TYPE_SIMPLE) {
             try {

--- a/Model/Cart/Item/Builder.php
+++ b/Model/Cart/Item/Builder.php
@@ -140,7 +140,7 @@ class Builder
         /** @var Item $parentItem */
         $parentItem = $item->getOptionByCode('product_type');
         if ($parentItem !== null) {
-            return $parentItem->getProduct()->getId();
+            return (string) $parentItem->getProduct()->getId();
         }
         if ($item->getProductType() === Type::TYPE_SIMPLE) {
             try {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "require-dev": {
     "phpmd/phpmd": "^2.5",
     "sebastian/phpcpd": "*",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="5.2.2"/>
+    <module name="Nosto_Tagging" setup_version="5.2.3"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Incorrect parent product id is used when adding a grouped product to cart

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
