### PR TITLE
Hotfix 5.2.5 - Fix MQ consumers memory issue

### DIFF
--- a/Model/Service/Sync/AbstractBulkConsumer.php
+++ b/Model/Service/Sync/AbstractBulkConsumer.php
@@ -99,7 +99,6 @@ abstract class AbstractBulkConsumer implements BulkConsumerInterface
             $message = __('Success.');
             $operation->setStatus(OperationInterface::STATUS_TYPE_COMPLETE)
                 ->setResultMessage($message);
-            $this->entityManager->save($operation);
         } catch (Exception $e) {
             $this->logger->critical(sprintf('Bulk uuid: %s. %s', $operation->getBulkUuid(), $e->getMessage()));
             /** @phan-suppress-next-line PhanTypeMismatchArgument */
@@ -107,6 +106,7 @@ abstract class AbstractBulkConsumer implements BulkConsumerInterface
             $operation->setStatus(OperationInterface::STATUS_TYPE_NOT_RETRIABLY_FAILED)
                 ->setErrorCode($e->getCode())
                 ->setResultMessage($message);
+        } finally {
             $this->entityManager->save($operation);
         }
     }

--- a/etc/queue_consumer.xml
+++ b/etc/queue_consumer.xml
@@ -38,13 +38,13 @@
     <consumer name="nosto_product_sync.update"
               queue="nosto_product_sync.update"
               connection="db"
-              maxMessages="5000"
+              maxMessages="10"
               consumerInstance="Magento\Framework\MessageQueue\Consumer"
               handler="Nosto\Tagging\Model\Service\Sync\Upsert\AsyncBulkConsumer::processOperation"/>
     <consumer name="nosto_product_sync.delete"
               queue="nosto_product_sync.delete"
               connection="db"
-              maxMessages="5000"
+              maxMessages="100"
               consumerInstance="Magento\Framework\MessageQueue\Consumer"
               handler="Nosto\Tagging\Model\Service\Sync\Delete\AsyncBulkConsumer::processOperation"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The maximum number of message that a consumer executes is too high. The memory is not released until the consumer finishes all the messages. This leads to an increase of the memory and a domino effect of failing messages with `Memory Out Of Bounds Error` exception when the max memory limit is reached.



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
