### PR TITLE
Add configuration for reloading recs after ATC

### DIFF
--- a/Block/Knockout.php
+++ b/Block/Knockout.php
@@ -139,7 +139,7 @@ class Knockout extends Template
      */
     public function isReloadRecsAfterAtcEnabled()
     {
-        $reload = false;
+        $reload = 0;
         try {
             $store = $this->storeManager->getStore();
             $reload = $this->nostoHelperData->isReloadRecsAfterAtcEnabled($store);

--- a/Block/Knockout.php
+++ b/Block/Knockout.php
@@ -38,34 +38,45 @@ namespace Nosto\Tagging\Block;
 
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
+use Magento\Store\Model\StoreManagerInterface;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+use Nosto\Tagging\Helper\Data as NostoHelperData;
 
 /**
  * Cart block used for cart tagging.
  */
 class Knockout extends Template
 {
+    /** @var NostoHelperAccount  */
     private $nostoHelperAccount;
+    /** @var NostoHelperScope  */
     private $nostoHelperScope;
+    /** @var NostoHelperData  */
+    private $nostoHelperData;
+    /** @var StoreManagerInterface */
+    private $storeManager;
 
     /**
-     * Constructor
-     *
+     * Knockout constructor.
      * @param Context $context
      * @param NostoHelperAccount $nostoHelperAccount
      * @param NostoHelperScope $nostoHelperScope
+     * @param NostoHelperData $nostoHelperData
      * @param array $data
      */
     public function __construct(
         Context $context,
         NostoHelperAccount $nostoHelperAccount,
         NostoHelperScope $nostoHelperScope,
+        NostoHelperData $nostoHelperData,
         array $data = []
     ) {
         parent::__construct($context, $data);
+        $this->storeManager = $context->getStoreManager();
         $this->nostoHelperAccount = $nostoHelperAccount;
         $this->nostoHelperScope = $nostoHelperScope;
+        $this->nostoHelperData = $nostoHelperData;
     }
 
     /**
@@ -110,5 +121,13 @@ class Knockout extends Template
         }
 
         return $jsLayout;
+    }
+
+    /**
+     * @return int
+     */
+    public function isReloadRecsAfterAtcEnabled() {
+        $store = $this->storeManager->getStore();
+        return $this->nostoHelperData->isReloadRecsAfterAtcEnabled($store);
     }
 }

--- a/Block/Knockout.php
+++ b/Block/Knockout.php
@@ -42,6 +42,8 @@ use Magento\Store\Model\StoreManagerInterface;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Helper\Data as NostoHelperData;
+use Nosto\Tagging\Logger\Logger;
+use Exception;
 
 /**
  * Cart block used for cart tagging.
@@ -50,12 +52,18 @@ class Knockout extends Template
 {
     /** @var NostoHelperAccount  */
     private $nostoHelperAccount;
+
     /** @var NostoHelperScope  */
     private $nostoHelperScope;
+
     /** @var NostoHelperData  */
     private $nostoHelperData;
+
     /** @var StoreManagerInterface */
     private $storeManager;
+
+    /** @var Logger */
+    private $logger;
 
     /**
      * Knockout constructor.
@@ -63,6 +71,7 @@ class Knockout extends Template
      * @param NostoHelperAccount $nostoHelperAccount
      * @param NostoHelperScope $nostoHelperScope
      * @param NostoHelperData $nostoHelperData
+     * @param Logger $logger
      * @param array $data
      */
     public function __construct(
@@ -70,6 +79,7 @@ class Knockout extends Template
         NostoHelperAccount $nostoHelperAccount,
         NostoHelperScope $nostoHelperScope,
         NostoHelperData $nostoHelperData,
+        Logger $logger,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -77,6 +87,7 @@ class Knockout extends Template
         $this->nostoHelperAccount = $nostoHelperAccount;
         $this->nostoHelperScope = $nostoHelperScope;
         $this->nostoHelperData = $nostoHelperData;
+        $this->logger = $logger;
     }
 
     /**
@@ -128,7 +139,14 @@ class Knockout extends Template
      */
     public function isReloadRecsAfterAtcEnabled()
     {
-        $store = $this->storeManager->getStore();
-        return $this->nostoHelperData->isReloadRecsAfterAtcEnabled($store);
+        $reload = false;
+        try {
+            $store = $this->storeManager->getStore();
+            $reload = $this->nostoHelperData->isReloadRecsAfterAtcEnabled($store);
+        } catch (Exception $e) {
+            $this->logger->debug("Could not get value for reloading recs after ATC");
+        } finally {
+            return $reload;
+        }
     }
 }

--- a/Block/Knockout.php
+++ b/Block/Knockout.php
@@ -126,7 +126,8 @@ class Knockout extends Template
     /**
      * @return int
      */
-    public function isReloadRecsAfterAtcEnabled() {
+    public function isReloadRecsAfterAtcEnabled()
+    {
         $store = $this->storeManager->getStore();
         return $this->nostoHelperData->isReloadRecsAfterAtcEnabled($store);
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 5.2.7
+* Add configuration to reload recs after adding product to cart
+
 ### 5.2.6
 * Get the correct product data by emulating the store
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -145,6 +145,11 @@ class Data extends AbstractHelper
     const XML_PATH_TRACK_MULTI_CHANNEL_ORDERS = 'nosto/flags/track_multi_channel_orders';
 
     /**
+     * Path to the configuration object that stores preference for reloading recs after adding product to cart
+     */
+    const XML_PATH_RELOAD_RECS_AFTER_ATC = 'nosto/flags/reload_recs_after_atc';
+
+    /**
      * Path to the configuration object for pricing variations
      */
     const XML_PATH_PRICING_VARIATION = 'nosto/multicurrency/pricing_variation';
@@ -420,6 +425,17 @@ class Data extends AbstractHelper
     public function isMultiChannelOrderTrackingEnabled(StoreInterface $store = null)
     {
         return (bool)$this->getStoreConfig(self::XML_PATH_TRACK_MULTI_CHANNEL_ORDERS, $store);
+    }
+
+    /**
+     * Returns if recs should be reloaded after adding product to cart
+     *
+     * @param StoreInterface|null $store
+     * @return int
+     */
+    public function isReloadRecsAfterAtcEnabled(StoreInterface $store = null)
+    {
+        return $this->getStoreConfig(self::XML_PATH_RELOAD_RECS_AFTER_ATC, $store);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "require-dev": {
     "phpmd/phpmd": "^2.5",
     "sebastian/phpcpd": "*",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -215,6 +215,14 @@
                     </comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="reload_recs_after_atc" translate="label comment" type="select" sortOrder="150"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Reload recs after reloading cart</label>
+                    <comment>
+                        <![CDATA[Set this yes if you want to reload recs after adding products to cart]]>
+                    </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
             <group id="attributes" translate="label" type="text" sortOrder="40" showInDefault="1"
                    showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -58,6 +58,7 @@
                 <indexer_memory>50</indexer_memory>
                 <tag_date_published>0</tag_date_published>
                 <track_multi_channel_orders>1</track_multi_channel_orders>
+                <reload_recs_after_atc>0</reload_recs_after_atc>
                 <product_caching>0</product_caching>
             </flags>
             <multicurrency>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="5.2.6"/>
+    <module name="Nosto_Tagging" setup_version="5.2.7"/>
 </config>

--- a/view/frontend/templates/cart.phtml
+++ b/view/frontend/templates/cart.phtml
@@ -39,7 +39,7 @@
  * Magento's KnockoutJS logic.
  *
  * @see \Nosto\Tagging\CustomerData\CartTagging
- * @var \Magento\Framework\View\Element\Template $block
+ * @var \Nosto\Tagging\Block\Knockout $block
  * @noinspection PhpFullyQualifiedNameUsageInspection
  */
 ?>
@@ -64,7 +64,17 @@
 </div>
 <!--suppress JSUnresolvedVariable -->
 <script type="text/x-magento-init">
-{"[data-role=nosto-cart-tagging]": {"Magento_Ui/js/core/app": <?= /* @escapeNotVerified */
-    $block->getJsLayout(); ?>}}
+{
+  "[data-role=nosto-cart-tagging]": {
+    "Magento_Ui/js/core/app": {
+      "components": {
+        "cartTagging": {
+          "component": "Nosto_Tagging/js/view/cart-tagging",
+          "refresh": "<?php echo /* @escapeNotVerified */ $block->isReloadRecsAfterAtcEnabled() ?>"
+        }
+      }
+    }
+  }
+}
 
 </script>

--- a/view/frontend/templates/cart.phtml
+++ b/view/frontend/templates/cart.phtml
@@ -70,7 +70,7 @@
       "components": {
         "cartTagging": {
           "component": "Nosto_Tagging/js/view/cart-tagging",
-          "refresh": "<?= /* @escapeNotVerified */ $block->isReloadRecsAfterAtcEnabled() ?>"
+          "refresh": "<?= $block->escapeHtml($block->isReloadRecsAfterAtcEnabled())?>"
         }
       }
     }

--- a/view/frontend/templates/cart.phtml
+++ b/view/frontend/templates/cart.phtml
@@ -70,7 +70,7 @@
       "components": {
         "cartTagging": {
           "component": "Nosto_Tagging/js/view/cart-tagging",
-          "refresh": "<?php echo /* @escapeNotVerified */ $block->isReloadRecsAfterAtcEnabled() ?>"
+          "refresh": "<?= /* @escapeNotVerified */ $block->isReloadRecsAfterAtcEnabled() ?>"
         }
       }
     }

--- a/view/frontend/web/js/view/cart-tagging.js
+++ b/view/frontend/web/js/view/cart-tagging.js
@@ -40,14 +40,22 @@ define([
   'nostojs'
 ], function (Component, customerData, nostojs) {
   'use strict';
+  var refreshRecs = false;
 
   // noinspection JSCheckFunctionSignatures
   return Component.extend({
-    initialize: function () {
+    /**
+    * Initialize Component
+    *
+    * @param config
+    */
+    initialize: function (config) {
       // noinspection JSUnresolvedFunction
       this._super();
       //noinspection JSUnusedGlobalSymbols
       this.cartTagging = customerData.get('cart-tagging');
+      //noinspection JSUnusedGlobalSymbols
+      refreshRecs = Boolean(parseInt(config.refresh))
     },
     sendTagging: function (elements, data) {
       //noinspection JSUnresolvedVariable
@@ -60,8 +68,13 @@ define([
           const element = document.querySelector("#nosto_cart_tagging");
           element.classList.remove('nosto_cart_hidden');
           element.classList.add('nosto_cart');
-          // noinspection JSUnresolvedFunction
-          api.resendCartTagging("nosto_cart_tagging");
+          if (refreshRecs === true) {
+              // noinspection JSUnresolvedFunction
+              api.loadRecommendations();
+          } else {
+              // noinspection JSUnresolvedFunction
+              api.resendCartTagging("nosto_cart_tagging");
+          }
         });
       }
     }

--- a/view/frontend/web/js/view/cart-tagging.js
+++ b/view/frontend/web/js/view/cart-tagging.js
@@ -40,7 +40,7 @@ define([
   'nostojs'
 ], function (Component, customerData, nostojs) {
   'use strict';
-  var refreshRecs = false;
+  let refreshRecs = false;
 
   // noinspection JSCheckFunctionSignatures
   return Component.extend({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cart based recommendations are not working as expected. This happens because the cart content is sent but the recs are not reloaded.  A new config is introduced to reload recs after ATC. 

![image](https://user-images.githubusercontent.com/44775916/113709394-18a6d600-96eb-11eb-87a0-48cb46b37e86.png)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
