### PR TITLE
Fix removal of simple products from indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 5.2.8
+* Fix simple products not being reindex issue
+
 ### 5.2.7
 * Add configuration to reload recs after adding product to cart
 

--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -200,10 +200,15 @@ class Repository
             $parentProductIds = $this->configurableProduct->getParentIdsByChild(
                 $product->getId()
             );
-            $parentProductIds = $this->filterWithDefaultVisibility($parentProductIds);
-            if (count($parentProductIds) == 0) {
-                throw new ParentProductDisabledException($product->getId());
+
+            //If product has parent ids, sanitize and check if they are not disabled
+            if (count($parentProductIds) != 0) {
+                $parentProductIds = $this->filterWithDefaultVisibility($parentProductIds);
+                if (count($parentProductIds) == 0) {
+                    throw new ParentProductDisabledException($product->getId());
+                }
             }
+
             $this->saveParentIdsToCache($product, $parentProductIds);
         }
         return $parentProductIds;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "5.2.7",
+  "version": "5.2.8",
   "require-dev": {
     "phpmd/phpmd": "^2.5",
     "sebastian/phpcpd": "*",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="5.2.7"/>
+    <module name="Nosto_Tagging" setup_version="5.2.8"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The simple products are excluded from the re-index. This bug was introduced in hotfix 5.2.2

## Related Issue
Solves #733

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
