### PR TITLE
Delete old _cl tables when upgrading to v5 

### DIFF
--- a/Setup/Core.php
+++ b/Setup/Core.php
@@ -49,6 +49,9 @@ abstract class Core
 {
     const PRODUCT_DATA_MAX_LENGTH = '32M';
 
+    const CL_TABLE_INDEX_PRODUCT_INVALIDATE = "nosto_index_product_invalidate_cl";
+    const CL_TABLE_INDEX_PRODUCT_DATA = "nosto_index_product_data_cl";
+
     /**
      * Creates a table for mapping Nosto customer to Magento's cart & orders
      *
@@ -206,5 +209,21 @@ abstract class Core
                 'Completed at Time'
             );
         $setup->getConnection()->createTable($table);
+    }
+
+    /**
+     * Deletes _cl tables from the older version of the module
+     *
+     * @param SchemaSetupInterface $setup
+     */
+    public function removeOldCliTables(SchemaSetupInterface $setup)
+    {
+        if ($setup->tableExists(self::CL_TABLE_INDEX_PRODUCT_INVALIDATE)) {
+            $setup->getConnection()->dropTable($setup->getTable(self::CL_TABLE_INDEX_PRODUCT_INVALIDATE));
+        }
+
+        if ($setup->tableExists(self::CL_TABLE_INDEX_PRODUCT_DATA)) {
+            $setup->getConnection()->dropTable($setup->getTable(self::CL_TABLE_INDEX_PRODUCT_DATA));
+        }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -76,6 +76,7 @@ class UpgradeSchema extends Core implements UpgradeSchemaInterface
         if (version_compare($fromVersion, '5.0.0', '<')) {
             try {
                 $this->createProductUpdateQueue($setup);
+                $this->removeOldCliTables($setup);
             } catch (Exception $e) {
                 $this->loger->exception($e);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When migrating from v4, two _cl tables are not dropped. They need to be deleted as they're note used anymore

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
