### PR TITLE
Add TTL to the product caching service and sync queue service

### DIFF
--- a/Model/Service/Cache/CacheService.php
+++ b/Model/Service/Cache/CacheService.php
@@ -43,6 +43,7 @@ use Nosto\Model\Product\Product;
 use Nosto\Tagging\Helper\Account as NostoAccountHelper;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
+use Nosto\Tagging\Model\Cache\Type\ProductData;
 use Nosto\Tagging\Model\Cache\Type\ProductDataInterface;
 use Nosto\Tagging\Model\Service\AbstractService;
 use Nosto\Tagging\Model\Service\Product\ProductSerializerInterface;
@@ -80,14 +81,17 @@ class CacheService extends AbstractService
     /**
      * @param NostoProductInterface $nostoProduct
      * @param StoreInterface $store
+     * @param int|null $lifeTime
      */
-    public function save(NostoProductInterface $nostoProduct, StoreInterface $store)
+    public function save(NostoProductInterface $nostoProduct, StoreInterface $store, $lifeTime)
     {
         try {
             $serializedNostoProduct = $this->productSerializer->toString($nostoProduct);
             $this->productDataCache->save(
                 $serializedNostoProduct,
-                $this->generateCacheKey($nostoProduct->getProductId(), $store->getId())
+                $this->generateCacheKey($nostoProduct->getProductId(), $store->getId()),
+                [ProductData::CACHE_TAG],
+                $lifeTime
             );
         } catch (Exception $e) {
             $this->getLogger()->exception($e);

--- a/Model/Service/Product/CachingProductService.php
+++ b/Model/Service/Product/CachingProductService.php
@@ -54,20 +54,26 @@ class CachingProductService implements ProductServiceInterface
     /** @var ProductServiceInterface */
     private $defaultProductService;
 
+    /** @var int|null */
+    private $lifeTime;
+
     /**
-     * Index constructor.
+     * CachingProductService constructor.
      * @param Logger $nostoLogger
      * @param CacheService $nostoCacheService
      * @param ProductServiceInterface $defaultProductService
+     * @param $lifeTime
      */
     public function __construct(
         Logger $nostoLogger,
         CacheService $nostoCacheService,
-        ProductServiceInterface $defaultProductService
+        ProductServiceInterface $defaultProductService,
+        $lifeTime
     ) {
         $this->nostoLogger = $nostoLogger;
         $this->nostoCacheService = $nostoCacheService;
         $this->defaultProductService = $defaultProductService;
+        $this->lifeTime = $lifeTime;
     }
 
     /**
@@ -86,7 +92,10 @@ class CachingProductService implements ProductServiceInterface
             if ($nostoProduct === null) {
                 $nostoProduct = $this->defaultProductService->getProduct($product, $store);
                 if ($nostoProduct !== null) {
-                    $this->nostoCacheService->save($nostoProduct, $store);
+                    if ($this->lifeTime < 0) {
+                        $this->lifeTime = null;
+                    }
+                    $this->nostoCacheService->save($nostoProduct, $store, $this->lifeTime);
                 }
             }
             return $nostoProduct;

--- a/Model/Service/Product/CachingProductService.php
+++ b/Model/Service/Product/CachingProductService.php
@@ -54,26 +54,20 @@ class CachingProductService implements ProductServiceInterface
     /** @var ProductServiceInterface */
     private $defaultProductService;
 
-    /** @var int|null */
-    private $lifeTime;
-
     /**
      * CachingProductService constructor.
      * @param Logger $nostoLogger
      * @param CacheService $nostoCacheService
      * @param ProductServiceInterface $defaultProductService
-     * @param $lifeTime
      */
     public function __construct(
         Logger $nostoLogger,
         CacheService $nostoCacheService,
-        ProductServiceInterface $defaultProductService,
-        $lifeTime
+        ProductServiceInterface $defaultProductService
     ) {
         $this->nostoLogger = $nostoLogger;
         $this->nostoCacheService = $nostoCacheService;
         $this->defaultProductService = $defaultProductService;
-        $this->lifeTime = $lifeTime;
     }
 
     /**
@@ -92,10 +86,7 @@ class CachingProductService implements ProductServiceInterface
             if ($nostoProduct === null) {
                 $nostoProduct = $this->defaultProductService->getProduct($product, $store);
                 if ($nostoProduct !== null) {
-                    if ($this->lifeTime < 0) {
-                        $this->lifeTime = null;
-                    }
-                    $this->nostoCacheService->save($nostoProduct, $store, $this->lifeTime);
+                    $this->nostoCacheService->save($nostoProduct, $store);
                 }
             }
             return $nostoProduct;

--- a/Model/Service/Product/Category/CachingCategoryService.php
+++ b/Model/Service/Product/Category/CachingCategoryService.php
@@ -53,7 +53,7 @@ class CachingCategoryService implements CategoryServiceInterface
     private $cache = [];
 
     /**
-     * Index constructor.
+     * CachingCategoryService constructor.
      * @param CategoryServiceInterface $categoryService
      */
     public function __construct(

--- a/Model/Service/Sync/Upsert/SyncService.php
+++ b/Model/Service/Sync/Upsert/SyncService.php
@@ -79,8 +79,11 @@ class SyncService extends AbstractService
     /** @var int */
     private $apiTimeout;
 
+    /** @var int|null */
+    private $lifeTime;
+
     /**
-     * Index constructor.
+     * Sync constructor.
      * @param NostoHelperAccount $nostoHelperAccount
      * @param NostoHelperUrl $nostoHelperUrl
      * @param NostoLogger $logger
@@ -89,6 +92,7 @@ class SyncService extends AbstractService
      * @param CacheService $cacheService
      * @param $apiBatchSize
      * @param $apiTimeout
+     * @param $lifeTime
      */
     public function __construct(
         NostoHelperAccount $nostoHelperAccount,
@@ -98,7 +102,8 @@ class SyncService extends AbstractService
         ProductServiceInterface $productService,
         CacheService $cacheService,
         $apiBatchSize,
-        $apiTimeout
+        $apiTimeout,
+        $lifeTime
     ) {
         parent::__construct($nostoDataHelper, $nostoHelperAccount, $logger);
         $this->productService = $productService;
@@ -108,6 +113,7 @@ class SyncService extends AbstractService
         $this->cacheService = $cacheService;
         $this->apiBatchSize = $apiBatchSize;
         $this->apiTimeout = $apiTimeout;
+        $this->lifeTime = $lifeTime;
     }
 
     /**
@@ -147,8 +153,11 @@ class SyncService extends AbstractService
                     throw new NostoException('Could not get product from the product service.');
                 }
                 $op->addProduct($nostoProduct);
+                if ($this->lifeTime < 0) {
+                    $this->lifeTime = null;
+                }
                 // phpcs:ignore
-                $this->cacheService->save($nostoProduct, $store);
+                $this->cacheService->save($nostoProduct, $store, $this->lifeTime);
                 $this->tickBenchmark(self::BENCHMARK_SYNC_NAME);
             }
 

--- a/Model/Service/Sync/Upsert/SyncService.php
+++ b/Model/Service/Sync/Upsert/SyncService.php
@@ -79,9 +79,6 @@ class SyncService extends AbstractService
     /** @var int */
     private $apiTimeout;
 
-    /** @var int|null */
-    private $lifeTime;
-
     /**
      * Sync constructor.
      * @param NostoHelperAccount $nostoHelperAccount
@@ -92,7 +89,6 @@ class SyncService extends AbstractService
      * @param CacheService $cacheService
      * @param $apiBatchSize
      * @param $apiTimeout
-     * @param $lifeTime
      */
     public function __construct(
         NostoHelperAccount $nostoHelperAccount,
@@ -102,8 +98,7 @@ class SyncService extends AbstractService
         ProductServiceInterface $productService,
         CacheService $cacheService,
         $apiBatchSize,
-        $apiTimeout,
-        $lifeTime
+        $apiTimeout
     ) {
         parent::__construct($nostoDataHelper, $nostoHelperAccount, $logger);
         $this->productService = $productService;
@@ -113,7 +108,6 @@ class SyncService extends AbstractService
         $this->cacheService = $cacheService;
         $this->apiBatchSize = $apiBatchSize;
         $this->apiTimeout = $apiTimeout;
-        $this->lifeTime = $lifeTime;
     }
 
     /**
@@ -153,11 +147,8 @@ class SyncService extends AbstractService
                     throw new NostoException('Could not get product from the product service.');
                 }
                 $op->addProduct($nostoProduct);
-                if ($this->lifeTime < 0) {
-                    $this->lifeTime = null;
-                }
                 // phpcs:ignore
-                $this->cacheService->save($nostoProduct, $store, $this->lifeTime);
+                $this->cacheService->save($nostoProduct, $store);
                 $this->tickBenchmark(self::BENCHMARK_SYNC_NAME);
             }
 

--- a/Model/Service/Update/QueueService.php
+++ b/Model/Service/Update/QueueService.php
@@ -67,7 +67,7 @@ class QueueService extends AbstractService
     private $batchSize;
 
     /**
-     * CacheService constructor.
+     * QueueService constructor.
      * @param QueueRepository $queueRepository
      * @param QueueBuilder $queueBuilder
      * @param NostoLogger $logger

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -146,6 +146,8 @@
             <argument name="defaultProductService" xsi:type="object">
                 Nosto\Tagging\Model\Service\Product\DefaultProductService
             </argument>
+            <!-- Default TTL value is equal to 7 days -->
+            <argument name="lifeTime" xsi:type="number">604800</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Model\Service\Product\SanitizingProductService">
@@ -224,6 +226,8 @@
             </argument>
             <argument name="apiBatchSize" xsi:type="number">50</argument>
             <argument name="apiTimeout" xsi:type="number">60</argument>
+            <!-- Default TTL value is equal to 7 days -->
+            <argument name="lifeTime" xsi:type="number">604800</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Model\Service\Sync\Delete\DeleteService">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -118,6 +118,12 @@
             <argument name="customerSession" xsi:type="object">Magento\Customer\Model\Session\Proxy</argument>
         </arguments>
     </type>
+    <type name="Nosto\Tagging\Model\Service\Cache\CacheService">
+        <arguments>
+            <!-- Default TTL value is equal to 7 days -->
+            <argument name="lifeTime" xsi:type="number">604800</argument>
+        </arguments>
+    </type>
     <type name="Nosto\Tagging\Model\Service\Product\Attribute\CachingAttributeService">
         <arguments>
             <argument name="attributeService" xsi:type="object">
@@ -146,8 +152,6 @@
             <argument name="defaultProductService" xsi:type="object">
                 Nosto\Tagging\Model\Service\Product\DefaultProductService
             </argument>
-            <!-- Default TTL value is equal to 7 days -->
-            <argument name="lifeTime" xsi:type="number">604800</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Model\Service\Product\SanitizingProductService">
@@ -226,8 +230,6 @@
             </argument>
             <argument name="apiBatchSize" xsi:type="number">50</argument>
             <argument name="apiTimeout" xsi:type="number">60</argument>
-            <!-- Default TTL value is equal to 7 days -->
-            <argument name="lifeTime" xsi:type="number">604800</argument>
         </arguments>
     </type>
     <type name="Nosto\Tagging\Model\Service\Sync\Delete\DeleteService">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Specify a ttl of 1 week, and inject the value through DI, so the merchant can change it in case needed.
<!--- Describe your changes -->

## Related Issue
Closes #749
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
No TTL is defined when storing Nosto product data into cache. If it's not defined than ttl would be forever, so the cache will not get invalidated until cleaned manually.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
