### PR TITLE
Hotfix 5.4.1: Fix availaibility building for products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 5.4.1
+* Fix product availability building for products with OOS threshold
+
 ### 5.4.0
 * Add functionality to send disabled products to Nosto
 * Add ttl for nosto_product_cache

--- a/Model/Product/Builder.php
+++ b/Model/Product/Builder.php
@@ -38,6 +38,7 @@ namespace Nosto\Tagging\Model\Product;
 
 use Exception;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status as ProductStatus;
 use Magento\Catalog\Model\Product\Gallery\ReadHandler as GalleryReadHandler;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Store\Model\Store;
@@ -405,7 +406,7 @@ class Builder
         $isInStock = $this->availabilityService->isInStock($product, $store);
         if (!$product->isVisibleInSiteVisibility()
             || (!$this->availabilityService->isAvailableInStore($product, $store) && $isInStock)
-            || !$product->isSalable()
+            || ($product->getStatus() == ProductStatus::STATUS_DISABLED)
         ) {
             $availability = ProductInterface::INVISIBLE;
         } elseif ($isInStock

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "require-dev": {
     "phpmd/phpmd": "^2.5",
     "sebastian/phpcpd": "*",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="5.4.0"/>
+    <module name="Nosto_Tagging" setup_version="5.4.1"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the availability builder condition from `isSalable` to more specific `getStatus` to determine _Invisible_ products. This solves issue where products with OOS threshold are wrongly marked as Invisible.
<!--- Describe your changes -->

## Related Issue
-
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Bug
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
