### PR TITLE
Add CurrencyInterface to fetch currency symbol

### DIFF
--- a/Model/Meta/Account/Settings/Currencies/Builder.php
+++ b/Model/Meta/Account/Settings/Currencies/Builder.php
@@ -88,7 +88,6 @@ class Builder
     /**
      * @param NostoLogger $logger
      * @param ManagerInterface $eventManager
-     * @param CurrencyFactory $currencyFactory
      * @param NostoHelperCurrency $nostoCurrencyHelper
      * @param LocaleResolver $localeResolver
      * @param CurrencyInterface $localeCurrency
@@ -102,7 +101,6 @@ class Builder
     ) {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
-        $this->currencyFactory = $currencyFactory;
         $this->nostoCurrencyHelper = $nostoCurrencyHelper;
         $this->localeResolver = $localeResolver;
         $this->localeCurrency = $localeCurrency;

--- a/Model/Meta/Account/Settings/Currencies/Builder.php
+++ b/Model/Meta/Account/Settings/Currencies/Builder.php
@@ -38,9 +38,9 @@
 namespace Nosto\Tagging\Model\Meta\Account\Settings\Currencies;
 
 use Exception;
-use Magento\Directory\Model\CurrencyFactory;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Locale\Bundle\DataBundle;
+use Magento\Framework\Locale\CurrencyInterface;
 use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
 use Magento\Store\Model\Store;
 use Nosto\Model\Format;
@@ -55,14 +55,14 @@ class Builder
     /** @var ManagerInterface  */
     private $eventManager;
 
-    /** @var CurrencyFactory  */
-    private $currencyFactory;
-
     /** @var LocaleResolver  */
     private $localeResolver;
 
     /** @var NostoHelperCurrency */
     private $nostoCurrencyHelper;
+
+    /** @var CurrencyInterface */
+    private $localeCurrency;
 
     /* List of zero decimal currencies in compliance with ISO-4217 */
     const ZERO_DECIMAL_CURRENCIES = [
@@ -91,19 +91,21 @@ class Builder
      * @param CurrencyFactory $currencyFactory
      * @param NostoHelperCurrency $nostoCurrencyHelper
      * @param LocaleResolver $localeResolver
+     * @param CurrencyInterface $localeCurrency
      */
     public function __construct(
         NostoLogger $logger,
         ManagerInterface $eventManager,
-        CurrencyFactory $currencyFactory,
         NostoHelperCurrency $nostoCurrencyHelper,
-        LocaleResolver $localeResolver
+        LocaleResolver $localeResolver,
+        CurrencyInterface $localeCurrency
     ) {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
         $this->currencyFactory = $currencyFactory;
         $this->nostoCurrencyHelper = $nostoCurrencyHelper;
         $this->localeResolver = $localeResolver;
+        $this->localeCurrency = $localeCurrency;
     }
 
     /**
@@ -134,10 +136,10 @@ class Builder
             if (is_array($currencyCodes) && !empty($currencyCodes)) {
                 foreach ($currencyCodes as $currencyCode) {
                     $finalPrecision = $this->isZeroDecimalCurrency($currencyCode) ? 0 : $precision;
-                    $currency = $this->currencyFactory->create()->load($currencyCode); // @codingStandardsIgnoreLine
-                    $currencies[$currency->getCode()] = new Format(
+                    $currency = $this->localeCurrency->getCurrency($currencyCode); // @codingStandardsIgnoreLine
+                    $currencies[$currency->getShortName()] = new Format(
                         $this->isSymbolBeforeAmount($localeData, $defaultSet),
-                        $currency->getCurrencySymbol(),
+                        $currency->getSymbol(),
                         $decimalSymbol,
                         $groupSymbol,
                         $finalPrecision


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add CurrencyInterface instead of factory. CurrencyInterface is using `Magento\Framework\CurrencyFactory` instead of `Magento\Directory\Model\CurrencyFactory` for fetching the Currency object. 
<!--- Describe your changes -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Due to performance issues when too many currencies are selected as active with multi-currency setting enabled.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
