### PR TITLE
Fix iteration on API sync service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
 
+### 6.1.6
+* Fix iteration on API sync service
+
 ### 6.1.5
 * Remove check for duplicate batch entries in the product update queue table
 

--- a/Model/Service/Sync/Upsert/SyncService.php
+++ b/Model/Service/Sync/Upsert/SyncService.php
@@ -150,7 +150,7 @@ class SyncService extends AbstractService
             $products = $this->productRepository->getByIds(
                 $page->getAllIds(
                     $this->apiBatchSize,
-                    ($page->getCurrentPageNumber() - 1) * $this->apiBatchSize
+                    ($iterator->getCurrentPageNumber() - 1) * $this->apiBatchSize
                 )
             );
             $index ++;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "require-dev": {
     "phpmd/phpmd": "^2.5",
     "sebastian/phpcpd": "*",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="6.1.5"/>
+    <module name="Nosto_Tagging" setup_version="6.1.6"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
SyncService doesn’t send back the IDs of the paginated collection but sends back all the IDs of the collection. Pagination was broken due to `getAllIds` method of the collection.
<!--- Describe your changes -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Magento 2.4.5, PHP 7.4
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
