### PR TITLE
Handle json_decode error, when value in null

### DIFF
--- a/Helper/Account.php
+++ b/Helper/Account.php
@@ -226,10 +226,20 @@ class Account extends AbstractHelper
             } catch (NostoException $e) {
                 throw new RuntimeException($e->getMessage());
             }
-            $tokens = json_decode(
-                $store->getConfig(self::XML_PATH_TOKENS),
-                true
-            );
+
+            $tokens = [];
+            $tokensJson = $store->getConfig(self::XML_PATH_TOKENS);
+            if (!empty($tokensJson)) {
+                try {
+                    $tokens = json_decode(
+                        $tokensJson,
+                        true
+                    );
+                } catch (Exception $e) {
+                    $this->logger->error($e->__toString());
+                }
+            }
+
             if (is_array($tokens) && !empty($tokens)) {
                 foreach ($tokens as $name => $value) {
                     try {


### PR DESCRIPTION
 Handle case where tokens in null, for newest php version like as php8.2 and above. Related ticket SSP-211