### PR TITLE
Include the category itself in the list of ids to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 8.0.2
+* Fix issue with category export where only parent categories are included
+
 ### 8.0.1
 * Add page-type tagging for Hyvä checkout page
 * Add default recommendation slots for Hyvä checkout page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
 ### 8.0.2
-* Fix issue with category export where only parent categories are included
+* Fix category export issue where only parent categories are included
 
 ### 8.0.1
 * Add page-type tagging for Hyvä checkout page

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -144,6 +144,7 @@ class CategoryUpdateService extends AbstractService
                 foreach ($parents as $id) {
                     $categoryIds[] = $id;
                 }
+                $categoryIds[] = $category->getId();
             } else {
                 $categoryIds[] = $category->getId();
             }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostotagging",
   "description": "Increase your conversion rate and average order value by delivering your customers personalized product recommendations throughout their shopping journey.",
   "type": "magento2-module",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "require-dev": {
     "phpmd/phpmd": "^2.5",
     "sebastian/phpcpd": "*",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,5 +37,5 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Tagging" setup_version="8.0.1"/>
+    <module name="Nosto_Tagging" setup_version="8.0.2"/>
 </config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When updating a given category, only the parents of that category are passed to RabbitMQ to be updated. 
The target category is left out. 

Fix it by including also the target category

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
