### PR TITLE
Fix check for constant that doesn't then cause undefined failure

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -588,7 +588,7 @@ class Data extends AbstractHelper
         $version = 'unknown';
         if ($this->productMetaData->getVersion()) {
             $version = $this->productMetaData->getVersion();
-        } elseif (defined(AppInterface::VERSION)) {
+        } elseif (defined('\Magento\Framework\AppInterface::VERSION')) {
             $version = AppInterface::VERSION;
         }
         return $version;


### PR DESCRIPTION
## Description
This fixes a language failure that occurs when the safety condition tries to execute but fails with this error:

```
[2025-08-29T15:47:18.005640+00:00] report.CRITICAL: Error: Undefined constant Magento\Framework\AppInterface::VERSION in /var/www_m2/site.com/htdocs/vendor/nosto/module-nostotagging/Helper/Data.php:575
Stack trace:
#0 /var/www_m2/site.com/htdocs/vendor/nosto/module-nostotagging/Observer/Cart/Add.php(127): Nosto\Tagging\Helper\Data->getPlatformVersion()
```


