### PR TITLE
NS-14087 fix category sync

### DIFF
--- a/Model/Indexer/CategoryIndexer.php
+++ b/Model/Indexer/CategoryIndexer.php
@@ -63,6 +63,9 @@ class CategoryIndexer extends AbstractIndexer
     /** @var CategoryUpdateService */
     private CategoryUpdateService $categoryUpdateService;
 
+    /** @var ProductIndexer */
+    private ProductIndexer $productIndexer;
+
     /** @var CategoryModeSwitcher */
     private CategoryModeSwitcher $modeSwitcher;
 
@@ -73,6 +76,7 @@ class CategoryIndexer extends AbstractIndexer
      * Constructor.
      * @param NostoHelperScope $nostoHelperScope
      * @param CategoryUpdateService $categoryUpdateService
+     * @param ProductIndexer $productIndexer
      * @param NostoLogger $logger
      * @param CollectionBuilder $categoryCollectionBuilder
      * @param CategoryModeSwitcher $modeSwitcher
@@ -85,6 +89,7 @@ class CategoryIndexer extends AbstractIndexer
     public function __construct(
         NostoHelperScope              $nostoHelperScope,
         CategoryUpdateService         $categoryUpdateService,
+        ProductIndexer                $productIndexer,
         NostoLogger                   $logger,
         CollectionBuilder             $categoryCollectionBuilder,
         CategoryModeSwitcher          $modeSwitcher,
@@ -95,6 +100,7 @@ class CategoryIndexer extends AbstractIndexer
         IndexerStatusServiceInterface $indexerStatusService
     ) {
         $this->categoryUpdateService = $categoryUpdateService;
+        $this->productIndexer = $productIndexer;
         $this->modeSwitcher = $modeSwitcher;
         $this->categoryCollectionBuilder = $categoryCollectionBuilder;
 
@@ -128,8 +134,13 @@ class CategoryIndexer extends AbstractIndexer
 
         $this->categoryUpdateService->addCollectionToUpdateMessageQueue(
             $collection,
-            $store
+            $store,
+            !empty($ids)
         );
+
+        if (empty($ids)) {
+            $this->productIndexer->doIndex($store, []);
+        }
     }
 
     /**

--- a/Model/Indexer/CategoryIndexer.php
+++ b/Model/Indexer/CategoryIndexer.php
@@ -63,9 +63,6 @@ class CategoryIndexer extends AbstractIndexer
     /** @var CategoryUpdateService */
     private CategoryUpdateService $categoryUpdateService;
 
-    /** @var ProductIndexer */
-    private ProductIndexer $productIndexer;
-
     /** @var CategoryModeSwitcher */
     private CategoryModeSwitcher $modeSwitcher;
 
@@ -76,7 +73,6 @@ class CategoryIndexer extends AbstractIndexer
      * Constructor.
      * @param NostoHelperScope $nostoHelperScope
      * @param CategoryUpdateService $categoryUpdateService
-     * @param ProductIndexer $productIndexer
      * @param NostoLogger $logger
      * @param CollectionBuilder $categoryCollectionBuilder
      * @param CategoryModeSwitcher $modeSwitcher
@@ -89,7 +85,6 @@ class CategoryIndexer extends AbstractIndexer
     public function __construct(
         NostoHelperScope              $nostoHelperScope,
         CategoryUpdateService         $categoryUpdateService,
-        ProductIndexer                $productIndexer,
         NostoLogger                   $logger,
         CollectionBuilder             $categoryCollectionBuilder,
         CategoryModeSwitcher          $modeSwitcher,
@@ -100,7 +95,6 @@ class CategoryIndexer extends AbstractIndexer
         IndexerStatusServiceInterface $indexerStatusService
     ) {
         $this->categoryUpdateService = $categoryUpdateService;
-        $this->productIndexer = $productIndexer;
         $this->modeSwitcher = $modeSwitcher;
         $this->categoryCollectionBuilder = $categoryCollectionBuilder;
 
@@ -137,10 +131,6 @@ class CategoryIndexer extends AbstractIndexer
             $store,
             !empty($ids)
         );
-
-        if (empty($ids)) {
-            $this->productIndexer->doIndex($store, []);
-        }
     }
 
     /**

--- a/Model/Service/Update/AbstractUpdateService.php
+++ b/Model/Service/Update/AbstractUpdateService.php
@@ -80,10 +80,11 @@ abstract class AbstractUpdateService extends AbstractService
      *
      * @param CategoryCollection|ProductCollection $collection
      * @param Store $store
+     * @param bool $runAfterPageQueued
      * @throws NostoException
      * @throws Exception
      */
-    protected function queueCollectionUpdates($collection, Store $store)
+    protected function queueCollectionUpdates($collection, Store $store, bool $runAfterPageQueued = true)
     {
         if ($this->getAccountHelper()->findAccount($store) === null) {
             $this->logDebugWithStore('No nosto account found for the store', $store);
@@ -108,7 +109,9 @@ abstract class AbstractUpdateService extends AbstractService
         /** @var CategoryCollection|ProductCollection $page */
         foreach ($iterator as $page) {
             $this->upsertBulkPublisher->execute($store->getId(), $this->getEntityIdsForPage($page));
-            $this->afterPageQueued($page, $store);
+            if ($runAfterPageQueued) {
+                $this->afterPageQueued($page, $store);
+            }
         }
     }
 

--- a/Model/Service/Update/AbstractUpdateService.php
+++ b/Model/Service/Update/AbstractUpdateService.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\Service\Update;
+
+use Exception;
+use Magento\Store\Model\Store;
+use Nosto\NostoException;
+use Nosto\Tagging\Helper\Account as NostoAccountHelper;
+use Nosto\Tagging\Helper\Data as NostoDataHelper;
+use Nosto\Tagging\Logger\Logger as NostoLogger;
+use Nosto\Tagging\Model\ResourceModel\Magento\Category\Collection as CategoryCollection;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
+use Nosto\Tagging\Model\Service\AbstractService;
+use Nosto\Tagging\Model\Service\Sync\BulkPublisherInterface;
+use Nosto\Tagging\Util\PagingIterator;
+
+abstract class AbstractUpdateService extends AbstractService
+{
+    /** @var int */
+    private int $batchSize;
+
+    /** @var BulkPublisherInterface */
+    private BulkPublisherInterface $upsertBulkPublisher;
+
+    /**
+     * @param NostoLogger $logger
+     * @param NostoDataHelper $nostoDataHelper
+     * @param NostoAccountHelper $nostoAccountHelper
+     * @param BulkPublisherInterface $upsertBulkPublisher
+     * @param int $batchSize
+     */
+    public function __construct(
+        NostoLogger $logger,
+        NostoDataHelper $nostoDataHelper,
+        NostoAccountHelper $nostoAccountHelper,
+        BulkPublisherInterface $upsertBulkPublisher,
+        int $batchSize
+    ) {
+        parent::__construct($nostoDataHelper, $nostoAccountHelper, $logger);
+        $this->upsertBulkPublisher = $upsertBulkPublisher;
+        $this->batchSize = $batchSize;
+    }
+
+    /**
+     * Sets collection items into the update message queue
+     *
+     * @param CategoryCollection|ProductCollection $collection
+     * @param Store $store
+     * @throws NostoException
+     * @throws Exception
+     */
+    protected function queueCollectionUpdates($collection, Store $store)
+    {
+        if ($this->getAccountHelper()->findAccount($store) === null) {
+            $this->logDebugWithStore('No nosto account found for the store', $store);
+            return;
+        }
+
+        $collection->setPageSize($this->batchSize);
+        $iterator = new PagingIterator($collection);
+        $this->getLogger()->debugWithSource(
+            sprintf(
+                'Adding %d %s to message queue for store %s - batch size is %s, total amount of pages %d',
+                $collection->getSize(),
+                $this->getEntityLogLabel(),
+                $store->getCode(),
+                $this->batchSize,
+                $iterator->getLastPageNumber()
+            ),
+            ['storeId' => $store->getId()],
+            $this
+        );
+
+        /** @var CategoryCollection|ProductCollection $page */
+        foreach ($iterator as $page) {
+            $this->upsertBulkPublisher->execute($store->getId(), $this->getEntityIdsForPage($page));
+            $this->afterPageQueued($page, $store);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    abstract protected function getEntityLogLabel(): string;
+
+    /**
+     * @param CategoryCollection|ProductCollection $collection
+     * @return array
+     */
+    abstract protected function getEntityIdsForPage($collection): array;
+
+    /**
+     * @param CategoryCollection|ProductCollection $collection
+     * @param Store $store
+     */
+    protected function afterPageQueued($collection, Store $store)
+    {
+    }
+}

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -105,6 +105,9 @@ class CategoryUpdateService extends AbstractUpdateService
      *
      * @param CategoryCollection $collection
      * @param Store $store
+     * @param bool $queueAffectedProductUpdates
+     * @throws NostoException
+     * @throws Exception
      */
     public function addCollectionToUpdateMessageQueue(
         CategoryCollection $collection,
@@ -176,16 +179,7 @@ class CategoryUpdateService extends AbstractUpdateService
     private function resolveAffectedCategoryIds(CategoryCollection $collection, Store $store): array
     {
         $categoryIds = [];
-        foreach ($collection->getItems() as $category) {
-            if (!$category instanceof Category) {
-                continue;
-            }
-
-            $categoryModel = $this->resolveStoreAwareCategory($category, $store);
-            if ($categoryModel === null) {
-                continue;
-            }
-
+        foreach ($this->resolveStoreAwareCategories($collection, $store) as $categoryModel) {
             $categoryIds[] = (int) $categoryModel->getId();
             $descendantIds = $categoryModel->getAllChildren(true);
             if (!empty($descendantIds)) {
@@ -199,25 +193,48 @@ class CategoryUpdateService extends AbstractUpdateService
     }
 
     /**
-     * Return a category model that is guaranteed to be loaded in the current store context.
+     * Resolve the page categories in the current store context with at most one reload query.
      *
-     * @param Category $category
+     * @param CategoryCollection $collection
      * @param Store $store
-     * @return Category|null
+     * @return Category[]
      */
-    private function resolveStoreAwareCategory(Category $category, Store $store): ?Category
+    private function resolveStoreAwareCategories(CategoryCollection $collection, Store $store): array
     {
-        if ((int) $category->getStoreId() === (int) $store->getId() && $category->getPath() !== '') {
-            return $category;
+        $categoriesById = [];
+        $categoryIdsToLoad = [];
+
+        /** @var Category $category */
+        foreach ($collection->getItems() as $category) {
+            if (!$category instanceof Category) {
+                continue;
+            }
+
+            $categoryId = (int) $category->getId();
+            if ((int) $category->getStoreId() === (int) $store->getId() && $category->getPath() !== '') {
+                $categoriesById[$categoryId] = $category;
+                continue;
+            }
+
+            $categoryIdsToLoad[] = $categoryId;
+        }
+
+        if (empty($categoryIdsToLoad)) {
+            return $categoriesById;
         }
 
         $categoryCollection = $this->categoryCollectionFactory->create();
         $categoryCollection->setStore($store);
         $categoryCollection->addAttributeToSelect('path');
-        $categoryCollection->addIdFilter([(int) $category->getId()]);
+        $categoryCollection->addIdFilter(array_values(array_unique($categoryIdsToLoad)));
 
-        $loadedCategory = $categoryCollection->getFirstItem();
-        return $loadedCategory instanceof Category ? $loadedCategory : null;
+        foreach ($categoryCollection->getItems() as $loadedCategory) {
+            if ($loadedCategory instanceof Category) {
+                $categoriesById[(int) $loadedCategory->getId()] = $loadedCategory;
+            }
+        }
+
+        return $categoriesById;
     }
 
     /**

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -40,6 +40,7 @@ use Exception;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Store\Model\Store;
+use Nosto\NostoException;
 use Nosto\Tagging\Exception\ParentCategoryDisabledException;
 use Nosto\Tagging\Helper\Account as NostoAccountHelper;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -46,6 +46,7 @@ use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Category\Repository as NostoCategoryRepository;
 use Nosto\Tagging\Model\ResourceModel\Magento\Category\Collection as CategoryCollection;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder as ProductCollectionBuilder;
 use Nosto\Tagging\Model\Service\AbstractService;
 use Nosto\Tagging\Util\PagingIterator;
 use Nosto\Tagging\Model\Service\Sync\BulkPublisherInterface;
@@ -63,6 +64,12 @@ class CategoryUpdateService extends AbstractService
     /** @var BulkPublisherInterface */
     private BulkPublisherInterface $upsertBulkPublisher;
 
+    /** @var ProductCollectionBuilder */
+    private ProductCollectionBuilder $productCollectionBuilder;
+
+    /** @var ProductUpdateService */
+    private ProductUpdateService $productUpdateService;
+
     /**
      * CategoryUpdateService constructor.
      * @param NostoLogger $logger
@@ -70,6 +77,8 @@ class CategoryUpdateService extends AbstractService
      * @param NostoAccountHelper $nostoAccountHelper
      * @param NostoCategoryRepository $nostoCategoryRepository
      * @param BulkPublisherInterface $upsertBulkPublisher
+     * @param ProductCollectionBuilder $productCollectionBuilder
+     * @param ProductUpdateService $productUpdateService
      * @param int $batchSize
      */
     public function __construct(
@@ -78,11 +87,15 @@ class CategoryUpdateService extends AbstractService
         NostoAccountHelper $nostoAccountHelper,
         NostoCategoryRepository $nostoCategoryRepository,
         BulkPublisherInterface $upsertBulkPublisher,
+        ProductCollectionBuilder $productCollectionBuilder,
+        ProductUpdateService $productUpdateService,
         int $batchSize
     ) {
         parent::__construct($nostoDataHelper, $nostoAccountHelper, $logger);
         $this->nostoCategoryRepository = $nostoCategoryRepository;
         $this->upsertBulkPublisher = $upsertBulkPublisher;
+        $this->productCollectionBuilder = $productCollectionBuilder;
+        $this->productUpdateService = $productUpdateService;
         $this->batchSize = $batchSize;
     }
 
@@ -116,6 +129,29 @@ class CategoryUpdateService extends AbstractService
         /** @var CategoryCollection $page */
         foreach ($iterator as $page) {
             $this->upsertBulkPublisher->execute($store->getId(), $this->toParentCategoryIds($page));
+            $this->addAffectedProductsToUpdateMessageQueue($page, $store);
+        }
+    }
+
+    /**
+     * Queue products assigned to changed categories so product payloads get refreshed category data.
+     *
+     * @param CategoryCollection $collection
+     * @param Store $store
+     * @throws Exception
+     */
+    private function addAffectedProductsToUpdateMessageQueue(CategoryCollection $collection, Store $store)
+    {
+        /** @var CategoryInterface $category */
+        foreach ($collection->getItems() as $category) {
+            $productCollection = $this->productCollectionBuilder
+                ->initDefault($store)
+                ->withDefaultVisibility($store)
+                ->build();
+            /** @phan-suppress-next-line PhanUndeclaredMethod */
+            $productCollection->addCategoryFilter($category);
+
+            $this->productUpdateService->addCollectionToUpdateMessageQueue($productCollection, $store);
         }
     }
 

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -114,8 +114,7 @@ class CategoryUpdateService extends AbstractUpdateService
         CategoryCollection $collection,
         Store $store,
         bool $queueAffectedProductUpdates = true
-    )
-    {
+    ) {
         $this->queueCollectionUpdates($collection, $store, $queueAffectedProductUpdates);
     }
 

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -115,12 +115,7 @@ class CategoryUpdateService extends AbstractService
         );
         /** @var CategoryCollection $page */
         foreach ($iterator as $page) {
-            $data = [
-                'entity' => self::CATEGORY_SERIVCE,
-                'categoryIds' => $this->toParentCategoryIds($page)
-            ];
-
-            $this->upsertBulkPublisher->execute($store->getId(), $data);
+            $this->upsertBulkPublisher->execute($store->getId(), $this->toParentCategoryIds($page));
         }
     }
 

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -53,8 +53,6 @@ use Nosto\Tagging\Model\Service\Sync\BulkPublisherInterface;
 
 class CategoryUpdateService extends AbstractService
 {
-    const CATEGORY_SERIVCE = 'category';
-
     /** @var NostoCategoryRepository $nostoCategoryRepository */
     private NostoCategoryRepository $nostoCategoryRepository;
 

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -40,28 +40,23 @@ use Exception;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Store\Model\Store;
-use Nosto\NostoException;
 use Nosto\Tagging\Exception\ParentCategoryDisabledException;
 use Nosto\Tagging\Helper\Account as NostoAccountHelper;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Category\Repository as NostoCategoryRepository;
 use Nosto\Tagging\Model\ResourceModel\Magento\Category\Collection as CategoryCollection;
+use Nosto\Tagging\Model\ResourceModel\Magento\Category\CollectionBuilder as CategoryCollectionBuilder;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder as ProductCollectionBuilder;
-use Nosto\Tagging\Model\Service\AbstractService;
-use Nosto\Tagging\Util\PagingIterator;
 use Nosto\Tagging\Model\Service\Sync\BulkPublisherInterface;
 
-class CategoryUpdateService extends AbstractService
+class CategoryUpdateService extends AbstractUpdateService
 {
     /** @var NostoCategoryRepository $nostoCategoryRepository */
     private NostoCategoryRepository $nostoCategoryRepository;
 
-    /** @var int $batchSize */
-    private int $batchSize;
-
-    /** @var BulkPublisherInterface */
-    private BulkPublisherInterface $upsertBulkPublisher;
+    /** @var CategoryCollectionBuilder */
+    private CategoryCollectionBuilder $categoryCollectionBuilder;
 
     /** @var ProductCollectionBuilder */
     private ProductCollectionBuilder $productCollectionBuilder;
@@ -76,6 +71,7 @@ class CategoryUpdateService extends AbstractService
      * @param NostoAccountHelper $nostoAccountHelper
      * @param NostoCategoryRepository $nostoCategoryRepository
      * @param BulkPublisherInterface $upsertBulkPublisher
+     * @param CategoryCollectionBuilder $categoryCollectionBuilder
      * @param ProductCollectionBuilder $productCollectionBuilder
      * @param ProductUpdateService $productUpdateService
      * @param int $batchSize
@@ -86,16 +82,22 @@ class CategoryUpdateService extends AbstractService
         NostoAccountHelper $nostoAccountHelper,
         NostoCategoryRepository $nostoCategoryRepository,
         BulkPublisherInterface $upsertBulkPublisher,
+        CategoryCollectionBuilder $categoryCollectionBuilder,
         ProductCollectionBuilder $productCollectionBuilder,
         ProductUpdateService $productUpdateService,
         int $batchSize
     ) {
-        parent::__construct($nostoDataHelper, $nostoAccountHelper, $logger);
+        parent::__construct(
+            $logger,
+            $nostoDataHelper,
+            $nostoAccountHelper,
+            $upsertBulkPublisher,
+            $batchSize
+        );
         $this->nostoCategoryRepository = $nostoCategoryRepository;
-        $this->upsertBulkPublisher = $upsertBulkPublisher;
+        $this->categoryCollectionBuilder = $categoryCollectionBuilder;
         $this->productCollectionBuilder = $productCollectionBuilder;
         $this->productUpdateService = $productUpdateService;
-        $this->batchSize = $batchSize;
     }
 
     /**
@@ -103,33 +105,37 @@ class CategoryUpdateService extends AbstractService
      *
      * @param CategoryCollection $collection
      * @param Store $store
-     * @throws NostoException
-     * @throws Exception
      */
     public function addCollectionToUpdateMessageQueue(CategoryCollection $collection, Store $store)
     {
-        if ($this->getAccountHelper()->findAccount($store) === null) {
-            $this->logDebugWithStore('No nosto account found for the store', $store);
-            return;
-        }
-        $collection->setPageSize($this->batchSize);
-        $iterator = new PagingIterator($collection);
-        $this->getLogger()->debugWithSource(
-            sprintf(
-                'Adding %d categories to message queue for store %s - batch size is %s, total amount of pages %d',
-                $collection->getSize(),
-                $store->getCode(),
-                $this->batchSize,
-                $iterator->getLastPageNumber()
-            ),
-            ['storeId' => $store->getId()],
-            $this
-        );
-        /** @var CategoryCollection $page */
-        foreach ($iterator as $page) {
-            $this->upsertBulkPublisher->execute($store->getId(), $this->toParentCategoryIds($page));
-            $this->addAffectedProductsToUpdateMessageQueue($page, $store);
-        }
+        $this->queueCollectionUpdates($collection, $store);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getEntityLogLabel(): string
+    {
+        return 'categories';
+    }
+
+    /**
+     * @param CategoryCollection $collection
+     * @return array
+     */
+    protected function getEntityIdsForPage($collection): array
+    {
+        return $this->toParentCategoryIds($collection);
+    }
+
+    /**
+     * @param CategoryCollection $collection
+     * @param Store $store
+     * @throws Exception
+     */
+    protected function afterPageQueued($collection, Store $store)
+    {
+        $this->addAffectedProductsToUpdateMessageQueue($collection, $store);
     }
 
     /**
@@ -141,14 +147,7 @@ class CategoryUpdateService extends AbstractService
      */
     private function addAffectedProductsToUpdateMessageQueue(CategoryCollection $collection, Store $store)
     {
-        $categoryIds = [];
-        foreach ($collection->getItems() as $category) {
-            if ($category instanceof Category) {
-                $categoryIds[] = (int) $category->getId();
-            }
-        }
-
-        $categoryIds = array_values(array_unique($categoryIds));
+        $categoryIds = $this->resolveAffectedCategoryIds($collection, $store);
         if (empty($categoryIds)) {
             return;
         }
@@ -160,6 +159,51 @@ class CategoryUpdateService extends AbstractService
         $productCollection->addCategoriesFilter(['eq' => $categoryIds]);
 
         $this->productUpdateService->addCollectionToUpdateMessageQueue($productCollection, $store);
+    }
+
+    /**
+     * Expand each changed category to include its descendant categories as well.
+     *
+     * @param CategoryCollection $collection
+     * @param Store $store
+     * @return int[]
+     * @throws Exception
+     */
+    private function resolveAffectedCategoryIds(CategoryCollection $collection, Store $store): array
+    {
+        $categoryIds = [];
+        foreach ($collection->getItems() as $category) {
+            if (!$category instanceof Category) {
+                continue;
+            }
+
+            $categoryIds[] = (int) $category->getId();
+            $path = (string) $category->getPath();
+            if ($path === '') {
+                $categoryCollection = $this->categoryCollectionBuilder
+                    ->initDefault($store)
+                    ->withAllAttributes()
+                    ->withIds([(int) $category->getId()])
+                    ->build();
+                $categoryPathCategory = $categoryCollection->getFirstItem();
+                $path = (string) $categoryPathCategory->getPath();
+            }
+
+            if ($path === '') {
+                continue;
+            }
+
+            $descendantCollection = $this->categoryCollectionBuilder
+                ->initDefault($store)
+                ->withAllAttributes()
+                ->build();
+            $descendantCollection->addAttributeToFilter('path', ['like' => $path . '/%']);
+            foreach ($descendantCollection->getItems() as $descendantCategory) {
+                $categoryIds[] = (int) $descendantCategory->getId();
+            }
+        }
+
+        return array_values(array_unique($categoryIds));
     }
 
     /**

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -46,7 +46,7 @@ use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Category\Repository as NostoCategoryRepository;
 use Nosto\Tagging\Model\ResourceModel\Magento\Category\Collection as CategoryCollection;
-use Nosto\Tagging\Model\ResourceModel\Magento\Category\CollectionBuilder as CategoryCollectionBuilder;
+use Nosto\Tagging\Model\ResourceModel\Magento\Category\CollectionFactory as CategoryCollectionFactory;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder as ProductCollectionBuilder;
 use Nosto\Tagging\Model\Service\Sync\BulkPublisherInterface;
 
@@ -55,11 +55,11 @@ class CategoryUpdateService extends AbstractUpdateService
     /** @var NostoCategoryRepository $nostoCategoryRepository */
     private NostoCategoryRepository $nostoCategoryRepository;
 
-    /** @var CategoryCollectionBuilder */
-    private CategoryCollectionBuilder $categoryCollectionBuilder;
-
     /** @var ProductCollectionBuilder */
     private ProductCollectionBuilder $productCollectionBuilder;
+
+    /** @var CategoryCollectionFactory */
+    private CategoryCollectionFactory $categoryCollectionFactory;
 
     /** @var ProductUpdateService */
     private ProductUpdateService $productUpdateService;
@@ -71,8 +71,8 @@ class CategoryUpdateService extends AbstractUpdateService
      * @param NostoAccountHelper $nostoAccountHelper
      * @param NostoCategoryRepository $nostoCategoryRepository
      * @param BulkPublisherInterface $upsertBulkPublisher
-     * @param CategoryCollectionBuilder $categoryCollectionBuilder
      * @param ProductCollectionBuilder $productCollectionBuilder
+     * @param CategoryCollectionFactory $categoryCollectionFactory
      * @param ProductUpdateService $productUpdateService
      * @param int $batchSize
      */
@@ -82,8 +82,8 @@ class CategoryUpdateService extends AbstractUpdateService
         NostoAccountHelper $nostoAccountHelper,
         NostoCategoryRepository $nostoCategoryRepository,
         BulkPublisherInterface $upsertBulkPublisher,
-        CategoryCollectionBuilder $categoryCollectionBuilder,
         ProductCollectionBuilder $productCollectionBuilder,
+        CategoryCollectionFactory $categoryCollectionFactory,
         ProductUpdateService $productUpdateService,
         int $batchSize
     ) {
@@ -95,8 +95,8 @@ class CategoryUpdateService extends AbstractUpdateService
             $batchSize
         );
         $this->nostoCategoryRepository = $nostoCategoryRepository;
-        $this->categoryCollectionBuilder = $categoryCollectionBuilder;
         $this->productCollectionBuilder = $productCollectionBuilder;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->productUpdateService = $productUpdateService;
     }
 
@@ -106,9 +106,13 @@ class CategoryUpdateService extends AbstractUpdateService
      * @param CategoryCollection $collection
      * @param Store $store
      */
-    public function addCollectionToUpdateMessageQueue(CategoryCollection $collection, Store $store)
+    public function addCollectionToUpdateMessageQueue(
+        CategoryCollection $collection,
+        Store $store,
+        bool $queueAffectedProductUpdates = true
+    )
     {
-        $this->queueCollectionUpdates($collection, $store);
+        $this->queueCollectionUpdates($collection, $store, $queueAffectedProductUpdates);
     }
 
     /**
@@ -156,7 +160,7 @@ class CategoryUpdateService extends AbstractUpdateService
             ->initDefault($store)
             ->withDefaultVisibility($store)
             ->build();
-        $productCollection->addCategoriesFilter(['eq' => $categoryIds]);
+        $productCollection->addCategoriesFilter(['in' => $categoryIds]);
 
         $this->productUpdateService->addCollectionToUpdateMessageQueue($productCollection, $store);
     }
@@ -177,36 +181,43 @@ class CategoryUpdateService extends AbstractUpdateService
                 continue;
             }
 
-            $categoryIds[] = (int) $category->getId();
-            $path = (string) $category->getPath();
-            if ($path === '') {
-                $categoryCollection = $this->categoryCollectionBuilder
-                    ->initDefault($store)
-                    ->withAllAttributes()
-                    ->withIds([(int) $category->getId()])
-                    ->build();
-                $categoryItems = $categoryCollection->getItems();
-                $categoryPathCategory = reset($categoryItems);
-                if ($categoryPathCategory instanceof Category) {
-                    $path = (string) $categoryPathCategory->getPath();
-                }
-            }
-
-            if ($path === '') {
+            $categoryModel = $this->resolveStoreAwareCategory($category, $store);
+            if ($categoryModel === null) {
                 continue;
             }
 
-            $descendantCollection = $this->categoryCollectionBuilder
-                ->initDefault($store)
-                ->withAllAttributes()
-                ->build();
-            $descendantCollection->addAttributeToFilter('path', ['like' => $path . '/%']);
-            foreach ($descendantCollection->getItems() as $descendantCategory) {
-                $categoryIds[] = (int) $descendantCategory->getId();
+            $categoryIds[] = (int) $categoryModel->getId();
+            $descendantIds = $categoryModel->getAllChildren(true);
+            if (!empty($descendantIds)) {
+                foreach ($descendantIds as $descendantId) {
+                    $categoryIds[] = (int) $descendantId;
+                }
             }
         }
 
         return array_values(array_unique($categoryIds));
+    }
+
+    /**
+     * Return a category model that is guaranteed to be loaded in the current store context.
+     *
+     * @param Category $category
+     * @param Store $store
+     * @return Category|null
+     */
+    private function resolveStoreAwareCategory(Category $category, Store $store): ?Category
+    {
+        if ((int) $category->getStoreId() === (int) $store->getId() && $category->getPath() !== '') {
+            return $category;
+        }
+
+        $categoryCollection = $this->categoryCollectionFactory->create();
+        $categoryCollection->setStore($store);
+        $categoryCollection->addAttributeToSelect('path');
+        $categoryCollection->addIdFilter([(int) $category->getId()]);
+
+        $loadedCategory = $categoryCollection->getFirstItem();
+        return $loadedCategory instanceof Category ? $loadedCategory : null;
     }
 
     /**

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -37,6 +37,7 @@
 namespace Nosto\Tagging\Model\Service\Update;
 
 use Exception;
+use Magento\Catalog\Model\Category;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
@@ -140,13 +141,15 @@ class CategoryUpdateService extends AbstractService
      */
     private function addAffectedProductsToUpdateMessageQueue(CategoryCollection $collection, Store $store)
     {
-        /** @var CategoryInterface $category */
         foreach ($collection->getItems() as $category) {
+            if (!$category instanceof Category) {
+                continue;
+            }
+
             $productCollection = $this->productCollectionBuilder
                 ->initDefault($store)
                 ->withDefaultVisibility($store)
                 ->build();
-            /** @phan-suppress-next-line PhanUndeclaredMethod */
             $productCollection->addCategoryFilter($category);
 
             $this->productUpdateService->addCollectionToUpdateMessageQueue($productCollection, $store);

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -108,7 +108,7 @@ class CategoryUpdateService extends AbstractUpdateService
      * @param Store $store
      * @param bool $queueAffectedProductUpdates
      * @throws NostoException
-     * @throws Exception
+     * @throws \Exception
      */
     public function addCollectionToUpdateMessageQueue(
         CategoryCollection $collection,

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -185,8 +185,11 @@ class CategoryUpdateService extends AbstractUpdateService
                     ->withAllAttributes()
                     ->withIds([(int) $category->getId()])
                     ->build();
-                $categoryPathCategory = $categoryCollection->getFirstItem();
-                $path = (string) $categoryPathCategory->getPath();
+                $categoryItems = $categoryCollection->getItems();
+                $categoryPathCategory = reset($categoryItems);
+                if ($categoryPathCategory instanceof Category) {
+                    $path = (string) $categoryPathCategory->getPath();
+                }
             }
 
             if ($path === '') {

--- a/Model/Service/Update/CategoryUpdateService.php
+++ b/Model/Service/Update/CategoryUpdateService.php
@@ -141,19 +141,25 @@ class CategoryUpdateService extends AbstractService
      */
     private function addAffectedProductsToUpdateMessageQueue(CategoryCollection $collection, Store $store)
     {
+        $categoryIds = [];
         foreach ($collection->getItems() as $category) {
-            if (!$category instanceof Category) {
-                continue;
+            if ($category instanceof Category) {
+                $categoryIds[] = (int) $category->getId();
             }
-
-            $productCollection = $this->productCollectionBuilder
-                ->initDefault($store)
-                ->withDefaultVisibility($store)
-                ->build();
-            $productCollection->addCategoryFilter($category);
-
-            $this->productUpdateService->addCollectionToUpdateMessageQueue($productCollection, $store);
         }
+
+        $categoryIds = array_values(array_unique($categoryIds));
+        if (empty($categoryIds)) {
+            return;
+        }
+
+        $productCollection = $this->productCollectionBuilder
+            ->initDefault($store)
+            ->withDefaultVisibility($store)
+            ->build();
+        $productCollection->addCategoriesFilter(['eq' => $categoryIds]);
+
+        $this->productUpdateService->addCollectionToUpdateMessageQueue($productCollection, $store);
     }
 
     /**

--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -38,6 +38,7 @@ namespace Nosto\Tagging\Model\Service\Update;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Store\Model\Store;
+use Nosto\NostoException;
 use Nosto\Tagging\Exception\ParentProductDisabledException;
 use Nosto\Tagging\Helper\Account as NostoAccountHelper;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;

--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -95,7 +95,7 @@ class ProductUpdateService extends AbstractUpdateService
      * @param ProductCollection $collection
      * @param Store $store
      * @throws NostoException
-     * @throws Exception
+     * @throws \Exception
      */
     public function addCollectionToUpdateMessageQueue(ProductCollection $collection, Store $store)
     {

--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -93,6 +93,8 @@ class ProductUpdateService extends AbstractUpdateService
      *
      * @param ProductCollection $collection
      * @param Store $store
+     * @throws NostoException
+     * @throws Exception
      */
     public function addCollectionToUpdateMessageQueue(ProductCollection $collection, Store $store)
     {

--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -36,30 +36,23 @@
 
 namespace Nosto\Tagging\Model\Service\Update;
 
-use Exception;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Store\Model\Store;
-use Nosto\NostoException;
 use Nosto\Tagging\Exception\ParentProductDisabledException;
 use Nosto\Tagging\Helper\Account as NostoAccountHelper;
 use Nosto\Tagging\Helper\Data as NostoDataHelper;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
-use Nosto\Tagging\Model\Service\AbstractService;
-use Nosto\Tagging\Util\PagingIterator;
 use Nosto\Tagging\Model\Service\Sync\BulkPublisherInterface;
 
-class ProductUpdateService extends AbstractService
+class ProductUpdateService extends AbstractUpdateService
 {
     /** @var NostoProductRepository $nostoProductRepository */
     private NostoProductRepository $nostoProductRepository;
 
     /** @var int $batchSize */
     private int $batchSize;
-
-    /** @var BulkPublisherInterface */
-    private BulkPublisherInterface $upsertBulkPublisher;
 
     /** @var BulkPublisherInterface */
     private BulkPublisherInterface $deleteBulkPublisher;
@@ -83,9 +76,14 @@ class ProductUpdateService extends AbstractService
         BulkPublisherInterface $deleteBulkPublisher,
         int $batchSize
     ) {
-        parent::__construct($nostoDataHelper, $nostoAccountHelper, $logger);
+        parent::__construct(
+            $logger,
+            $nostoDataHelper,
+            $nostoAccountHelper,
+            $upsertBulkPublisher,
+            $batchSize
+        );
         $this->nostoProductRepository = $nostoProductRepository;
-        $this->upsertBulkPublisher = $upsertBulkPublisher;
         $this->deleteBulkPublisher = $deleteBulkPublisher;
         $this->batchSize = $batchSize;
     }
@@ -95,32 +93,27 @@ class ProductUpdateService extends AbstractService
      *
      * @param ProductCollection $collection
      * @param Store $store
-     * @throws NostoException
-     * @throws Exception
      */
     public function addCollectionToUpdateMessageQueue(ProductCollection $collection, Store $store)
     {
-        if ($this->getAccountHelper()->findAccount($store) === null) {
-            $this->logDebugWithStore('No nosto account found for the store', $store);
-            return;
-        }
-        $collection->setPageSize($this->batchSize);
-        $iterator = new PagingIterator($collection);
-        $this->getLogger()->debugWithSource(
-            sprintf(
-                'Adding %d products to message queue for store %s - batch size is %s, total amount of pages %d',
-                $collection->getSize(),
-                $store->getCode(),
-                $this->batchSize,
-                $iterator->getLastPageNumber()
-            ),
-            ['storeId' => $store->getId()],
-            $this
-        );
-        /** @var ProductCollection $page */
-        foreach ($iterator as $page) {
-            $this->upsertBulkPublisher->execute($store->getId(), $this->toParentProductIds($page));
-        }
+        $this->queueCollectionUpdates($collection, $store);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getEntityLogLabel(): string
+    {
+        return 'products';
+    }
+
+    /**
+     * @param ProductCollection $collection
+     * @return array
+     */
+    protected function getEntityIdsForPage($collection): array
+    {
+        return $this->toParentProductIds($collection);
     }
 
     /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -270,7 +270,7 @@
     </type>
     <type name="Nosto\Tagging\Model\Service\Update\CategoryUpdateService">
         <arguments>
-            <argument name="upsertCategoryBulkPublisher" xsi:type="object" shared="false">
+            <argument name="upsertBulkPublisher" xsi:type="object" shared="false">
                 Nosto\Tagging\Model\Service\Sync\Upsert\Category\AsyncBulkPublisher
             </argument>
             <argument name="batchSize" xsi:type="number">500</argument>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
category sync now sends a flat entity_ids array instead of the wrapped { entity, categoryIds } payload also resyncs the products assigned to that category, because child products were not being updated when only the category changed.

## Related Issue
https://nostosolutions.atlassian.net/browse/NS-14087

## Motivation and Context
fix the SQL/payload mismatch that broke category bulk sync
Category name changes were syncing the category itself, but the associated products were not being requeued, so product data (category field) in Nosto became stale until a product save happened.


## How Has This Been Tested?
Saved a category in Magento Admin and verified the category update and the affected products were synced correctly.


## Documentation:

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
