### PR TITLE
Ns 13999 fix category availabily issue

### DIFF
--- a/Model/Category/Builder.php
+++ b/Model/Category/Builder.php
@@ -136,10 +136,10 @@ class Builder
     private function resolveCategoryName(Category $category, Store $store): string
     {
         if ($category->hasData('name') && $category->getName() !== null) {
-            return (string)$category->getName();
+            return $category->getName();
         }
 
-        return (string)$this->getCategoryNameById((int)$category->getId(), (int)$store->getId());
+        return $this->getCategoryNameById((int)$category->getId(), $store->getId());
     }
 
     /**
@@ -151,15 +151,11 @@ class Builder
     private function resolveCategoryAvailability(Category $category, Store $store): bool
     {
         if ($category->hasData('is_active')) {
-            return (bool)$category->getIsActive();
-        }
-
-        if (empty($category->getId())) {
-            return false;
+            return $category->getIsActive();
         }
 
         return (bool)$this->categoryRepository
-            ->get($category->getId(), $store->getId())
+            ->get((int)$category->getId(), $store->getId())
             ->getIsActive();
     }
 }

--- a/Model/Category/Builder.php
+++ b/Model/Category/Builder.php
@@ -100,7 +100,7 @@ class Builder
             $nostoCategory->setPath($category->getPath() ?? '');
             $nostoCategory->setCategoryString($pathString ?? '');
             $nostoCategory->setUrl($this->urlBuilder->getCategoryUrlInStore($category, $store));
-            $nostoCategory->setAvailable($category->getIsActive() ?? false);
+            $nostoCategory->setAvailable($this->resolveCategoryAvailability($category, $store));
         } catch (Exception $e) {
             $this->logger->exception($e);
         }
@@ -125,5 +125,26 @@ class Builder
     private function getCategoryNameById(int $id, int $storeId)
     {
         return $this->categoryRepository->get($id, $storeId)->getName();
+    }
+
+    /**
+     * @param Category $category
+     * @param Store $store
+     * @return bool
+     * @throws NoSuchEntityException
+     */
+    private function resolveCategoryAvailability(Category $category, Store $store): bool
+    {
+        if ($category->hasData('is_active')) {
+            return (bool)$category->getIsActive();
+        }
+
+        if (empty($category->getId())) {
+            return false;
+        }
+
+        return (bool)$this->categoryRepository
+            ->get($category->getId(), $store->getId())
+            ->getIsActive();
     }
 }

--- a/Model/Category/Builder.php
+++ b/Model/Category/Builder.php
@@ -95,7 +95,7 @@ class Builder
         try {
             $nostoCategory->setId($category->getId());
             $nostoCategory->setParentId($category->getParentId());
-            $nostoCategory->setTitle($this->getCategoryNameById($category->getId(), $store->getId()));
+            $nostoCategory->setTitle($this->resolveCategoryName($category, $store));
             $pathString = $this->nostoCategoryService->getCategory($category, $store);
             $nostoCategory->setPath($category->getPath() ?? '');
             $nostoCategory->setCategoryString($pathString ?? '');
@@ -125,6 +125,21 @@ class Builder
     private function getCategoryNameById(int $id, int $storeId)
     {
         return $this->categoryRepository->get($id, $storeId)->getName();
+    }
+
+    /**
+     * @param Category $category
+     * @param Store $store
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    private function resolveCategoryName(Category $category, Store $store): string
+    {
+        if ($category->hasData('name') && $category->getName() !== null) {
+            return (string)$category->getName();
+        }
+
+        return (string)$this->getCategoryNameById((int)$category->getId(), (int)$store->getId());
     }
 
     /**

--- a/Model/ResourceModel/Magento/Category/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Category/CollectionBuilder.php
@@ -184,7 +184,7 @@ class CollectionBuilder
      */
     private function withSyncAttributes()
     {
-        $this->categoryCollection->addAttributeToSelect('is_active');
+        $this->categoryCollection->addAttributeToSelect(['is_active', 'name']);
         return $this;
     }
 

--- a/Model/ResourceModel/Magento/Category/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Category/CollectionBuilder.php
@@ -173,7 +173,19 @@ class CollectionBuilder
         return $this
             ->reset()
             ->withStore($store)
+            ->withSyncAttributes()
             ->setSort(EntityInterface::CREATED_AT, $this->categoryCollection::SORT_ORDER_DESC);
+    }
+
+    /**
+     * Defines attributes required for building Nosto category payloads
+     *
+     * @return $this
+     */
+    private function withSyncAttributes()
+    {
+        $this->categoryCollection->addAttributeToSelect('is_active');
+        return $this;
     }
 
     /**

--- a/Model/Service/Sync/Upsert/Category/AsyncBulkConsumer.php
+++ b/Model/Service/Sync/Upsert/Category/AsyncBulkConsumer.php
@@ -98,6 +98,7 @@ class AsyncBulkConsumer extends AbstractBulkConsumer
     {
         $store = $this->nostoScopeHelper->getStore($storeId);
         $categoryCollection = $this->collectionFactory->create()
+            ->addAttributeToSelect('is_active')
             ->addIdsToFilter($entityIds);
         try {
             $this->syncService->sync($categoryCollection, $store);

--- a/Model/Service/Sync/Upsert/Category/AsyncBulkConsumer.php
+++ b/Model/Service/Sync/Upsert/Category/AsyncBulkConsumer.php
@@ -100,7 +100,7 @@ class AsyncBulkConsumer extends AbstractBulkConsumer
         $categoryCollection = $this->collectionFactory->create()
             ->setProductStoreId($store->getId())
             ->setStore($store)
-            ->addAttributeToSelect('is_active')
+            ->addAttributeToSelect(['is_active', 'name'])
             ->addIdsToFilter($entityIds);
         try {
             $this->syncService->sync($categoryCollection, $store);

--- a/Model/Service/Sync/Upsert/Category/AsyncBulkConsumer.php
+++ b/Model/Service/Sync/Upsert/Category/AsyncBulkConsumer.php
@@ -98,6 +98,8 @@ class AsyncBulkConsumer extends AbstractBulkConsumer
     {
         $store = $this->nostoScopeHelper->getStore($storeId);
         $categoryCollection = $this->collectionFactory->create()
+            ->setProductStoreId($store->getId())
+            ->setStore($store)
             ->addAttributeToSelect('is_active')
             ->addIdsToFilter($entityIds);
         try {

--- a/Model/Service/Sync/Upsert/Category/SyncService.php
+++ b/Model/Service/Sync/Upsert/Category/SyncService.php
@@ -115,6 +115,7 @@ class SyncService extends AbstractService
             foreach ($page as $category) {
                 // Needs to adjust on the SDK to batch instead of calling the API for each category
                 try {
+                    $categoryIdsInBatch[] = $category->getId();
                     $nostoCategory = $this->categoryBuilder->build($category, $store);
                     $op = new CategoryUpdate($nostoCategory, $account, $this->nostoHelperUrl->getActiveDomain($store));
                     $op->setResponseTimeout($this->apiTimeout);

--- a/Model/Service/Sync/Upsert/Category/SyncService.php
+++ b/Model/Service/Sync/Upsert/Category/SyncService.php
@@ -104,13 +104,13 @@ class SyncService extends AbstractService
             );
             return;
         }
-        $categoryIdsInBatch = [];
         $account = $this->nostoHelperAccount->findAccount($store);
         $this->startBenchmark('nosto_category_upsert', self::BENCHMARK_SYNC_BREAKPOINT);
         $collection->setPageSize($this->apiBatchSize);
         $iterator = new PagingIterator($collection);
         /** @var CategoryCollection $page */
         foreach ($iterator as $page) {
+            $categoryIdsInBatch = [];
             $this->checkMemoryConsumption('category sync');
             foreach ($page as $category) {
                 // Needs to adjust on the SDK to batch instead of calling the API for each category

--- a/Plugin/CategoryUpdate.php
+++ b/Plugin/CategoryUpdate.php
@@ -84,10 +84,15 @@ class CategoryUpdate
         Closure $proceed,
         AbstractModel $category
     ) {
+        $result = $proceed($category);
+
         try {
-            $categoryCollection = $this->categoryCollectionBuilder->withIds([$category->getId()])->build();
             foreach ($category->getStoreIds() as $storeId) {
                 $store = $this->nostoHelperScope->getStore($storeId);
+                $categoryCollection = $this->categoryCollectionBuilder
+                    ->initDefault($store)
+                    ->withIds([(int)$category->getId()])
+                    ->build();
                 $this->categoryUpdateService->addCollectionToUpdateMessageQueue($categoryCollection, $store);
             }
         } catch (\Exception $e) {
@@ -98,6 +103,6 @@ class CategoryUpdate
                 )
             );
         }
-        return $proceed($category);
+        return $result;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes incorrect category availability updates sent to Nosto during async category sync.

Changes include:
Resolve category availability safely in the category builder.
Reload store-scoped is_active from Magento when it is missing from the category object.
Ensure category sync collections load is_active.
Queue category updates after the Magento category save completes, so saved category state is used.

## Related Issue
https://nostosolutions.atlassian.net/browse/NS-13999

## Motivation and Context
Some category saves could send two Nosto updates within seconds. The first update correctly marked the category as available, while the later async update could mark it unavailable because is_active was missing from the category object and defaulted to false.

This caused valid categories to be silently marked unavailable in Nosto, affecting search and autocomplete visibility.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
