### PR TITLE
Always add simple product id to queue

### DIFF
--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -157,9 +157,8 @@ class ProductUpdateService extends AbstractUpdateService
                 foreach ($parents as $id) {
                     $productIds[] = $id;
                 }
-            } else {
-                $productIds[] = $product->getId();
             }
+            $productIds[] = $product->getId();
         }
         return array_unique($productIds);
     }


### PR DESCRIPTION
## Motivation and Context

The simple product ID always needs to be added to the queue. Simple products which are assigned to a configurable product can also be visible on the frontend stand alone and should be synced to Nosto

## Description

The simple product ID always needs to be added to the queue. Simple products which are assigned to a configurable product can also be visible on the frontend stand alone and should be synced to Nosto

## How Has This Been Tested?

Have a configurable product with a simple product linked to it. Disabled the configurable product. Enable to simple product and make it visible in catalog and search. Product should be indexed to Nosto. 

