### PR TITLE
Sync simple products even when parent is disabled

### DIFF
--- a/Model/Product/Repository.php
+++ b/Model/Product/Repository.php
@@ -215,9 +215,6 @@ class Repository
             //If product has parent ids, sanitize and check if they are not disabled
             if (count($parentProductIds) != 0) {
                 $parentProductIds = $this->filterWithDefaultVisibility($parentProductIds);
-                if (count($parentProductIds) == 0) {
-                    throw new ParentProductDisabledException($product->getId());
-                }
             }
 
             $this->saveParentIdsToCache($product, $parentProductIds);


### PR DESCRIPTION
## Motivation and Context

The simple product ID always needs to be added to the queue. Simple products which are assigned to a configurable product can also be visible on the frontend stand alone and should be synced to Nosto

## Description

The simple product ID always needs to be added to the queue. Simple products which are assigned to a configurable product can also be visible on the frontend stand alone and should be synced to Nosto

## How Has This Been Tested?

Have a configurable product with a simple product linked to it. Disabled the configurable product. Enable to simple product and make it visible in catalog and search. Product should be indexed to Nosto. 

