### PR TITLE
Fix/current format handling

### DIFF
--- a/Model/Meta/Account/Settings/Currencies/Builder.php
+++ b/Model/Meta/Account/Settings/Currencies/Builder.php
@@ -256,11 +256,19 @@ class Builder
     {
         $formats = [];
         foreach ($data as $code => $item) {
+            if (!is_array($item) || !isset(
+                $item['currency_before_amount'],
+                $item['currency_token'],
+                $item['decimal_character'],
+                $item['decimal_places']
+            )) {
+                continue;
+            }
             $formats[$code] = new Format(
                 (bool)$item['currency_before_amount'],
                 $item['currency_token'],
                 $item['decimal_character'],
-                $item['grouping_separator'],
+                $item['grouping_separator'] ?? null,
                 (int)$item['decimal_places']
             );
         }

--- a/Model/Meta/Account/Settings/Currencies/Builder.php
+++ b/Model/Meta/Account/Settings/Currencies/Builder.php
@@ -203,7 +203,15 @@ class Builder
         $cacheKey = self::CACHE_KEY_PREFIX . $store->getId();
         $cached = $this->cache->load($cacheKey);
         if ($cached !== false) {
-            return $this->deserializeFormats($this->serializer->unserialize($cached));
+            try {
+                $data = $this->serializer->unserialize($cached);
+                if (is_array($data)) {
+                    return $this->deserializeFormats($data);
+                }
+            } catch (Exception $e) {
+                $this->logger->exception($e);
+            }
+            $this->cache->remove($cacheKey);
         }
 
         try {

--- a/Model/Meta/Account/Settings/Currencies/Builder.php
+++ b/Model/Meta/Account/Settings/Currencies/Builder.php
@@ -120,8 +120,7 @@ class Builder
         NostoHelperAccount  $nostoHelperAccount,
         CacheInterface      $cache,
         SerializerInterface $serializer
-    )
-    {
+    ) {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
         $this->currencyFactory = $currencyFactory;

--- a/Model/Meta/Account/Settings/Currencies/Builder.php
+++ b/Model/Meta/Account/Settings/Currencies/Builder.php
@@ -53,16 +53,16 @@ use Nosto\Tagging\Model\Operation\GetSettings;
 
 class Builder
 {
-    /** @var NostoLogger  */
+    /** @var NostoLogger */
     private NostoLogger $logger;
 
-    /** @var ManagerInterface  */
+    /** @var ManagerInterface */
     private ManagerInterface $eventManager;
 
-    /** @var CurrencyFactory  */
+    /** @var CurrencyFactory */
     private CurrencyFactory $currencyFactory;
 
-    /** @var LocaleResolver  */
+    /** @var LocaleResolver */
     private LocaleResolver $localeResolver;
 
     /** @var NostoHelperCurrency */
@@ -112,15 +112,16 @@ class Builder
      * @param SerializerInterface $serializer
      */
     public function __construct(
-        NostoLogger $logger,
-        ManagerInterface $eventManager,
-        CurrencyFactory $currencyFactory,
+        NostoLogger         $logger,
+        ManagerInterface    $eventManager,
+        CurrencyFactory     $currencyFactory,
         NostoHelperCurrency $nostoCurrencyHelper,
-        LocaleResolver $localeResolver,
-        NostoHelperAccount $nostoHelperAccount,
-        CacheInterface $cache,
+        LocaleResolver      $localeResolver,
+        NostoHelperAccount  $nostoHelperAccount,
+        CacheInterface      $cache,
         SerializerInterface $serializer
-    ) {
+    )
+    {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
         $this->currencyFactory = $currencyFactory;

--- a/Model/Meta/Account/Settings/Currencies/Builder.php
+++ b/Model/Meta/Account/Settings/Currencies/Builder.php
@@ -39,13 +39,17 @@ namespace Nosto\Tagging\Model\Meta\Account\Settings\Currencies;
 
 use Exception;
 use Magento\Directory\Model\CurrencyFactory;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Locale\Bundle\DataBundle;
 use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
+use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Store\Model\Store;
 use Nosto\Model\Format;
+use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Helper\Currency as NostoHelperCurrency;
+use Nosto\Tagging\Model\Operation\GetSettings;
 
 class Builder
 {
@@ -63,6 +67,18 @@ class Builder
 
     /** @var NostoHelperCurrency */
     private NostoHelperCurrency $nostoCurrencyHelper;
+
+    /** @var NostoHelperAccount */
+    private NostoHelperAccount $nostoHelperAccount;
+
+    /** @var CacheInterface */
+    private CacheInterface $cache;
+
+    /** @var SerializerInterface */
+    private SerializerInterface $serializer;
+
+    private const CACHE_KEY_PREFIX = 'nosto_currency_formats_';
+    private const CACHE_TTL = 3600;
 
     /* List of zero decimal currencies in compliance with ISO-4217 */
     public const ZERO_DECIMAL_CURRENCIES = [
@@ -91,19 +107,28 @@ class Builder
      * @param CurrencyFactory $currencyFactory
      * @param NostoHelperCurrency $nostoCurrencyHelper
      * @param LocaleResolver $localeResolver
+     * @param NostoHelperAccount $nostoHelperAccount
+     * @param CacheInterface $cache
+     * @param SerializerInterface $serializer
      */
     public function __construct(
         NostoLogger $logger,
         ManagerInterface $eventManager,
         CurrencyFactory $currencyFactory,
         NostoHelperCurrency $nostoCurrencyHelper,
-        LocaleResolver $localeResolver
+        LocaleResolver $localeResolver,
+        NostoHelperAccount $nostoHelperAccount,
+        CacheInterface $cache,
+        SerializerInterface $serializer
     ) {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
         $this->currencyFactory = $currencyFactory;
         $this->nostoCurrencyHelper = $nostoCurrencyHelper;
         $this->localeResolver = $localeResolver;
+        $this->nostoHelperAccount = $nostoHelperAccount;
+        $this->cache = $cache;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -115,6 +140,8 @@ class Builder
     {
         $currencies = [];
         try {
+            $nostoCurrencies = $this->fetchNostoCurrencyFormats($store);
+
             $storeLocale = $store->getConfig('general/locale/code');
             $localeCode = $storeLocale ?: $this->localeResolver->getLocale();
             $localeData = (new DataBundle())->get($localeCode);
@@ -133,6 +160,11 @@ class Builder
             }
             if (is_array($currencyCodes) && !empty($currencyCodes)) {
                 foreach ($currencyCodes as $currencyCode) {
+                    // Prioritize format already configured in Nosto over locally derived one
+                    if (isset($nostoCurrencies[$currencyCode])) {
+                        $currencies[$currencyCode] = $nostoCurrencies[$currencyCode];
+                        continue;
+                    }
                     $finalPrecision = $this->isZeroDecimalCurrency($currencyCode) ? 0 : $precision;
                     $currency = $this->currencyFactory->create()->load($currencyCode); // @codingStandardsIgnoreLine
                     $currencies[$currency->getCode()] = new Format(
@@ -151,6 +183,80 @@ class Builder
         $this->eventManager->dispatch('nosto_currencies_load_after', ['currencies' => $currencies]);
 
         return $currencies;
+    }
+
+    /**
+     * Fetches currency formats already configured in Nosto for this store's account.
+     * Results are cached for CACHE_TTL seconds to avoid repeated API calls.
+     * Returns an empty array when no account exists or the request fails.
+     *
+     * @param Store $store
+     * @return Format[]
+     */
+    private function fetchNostoCurrencyFormats(Store $store): array
+    {
+        $account = $this->nostoHelperAccount->findAccount($store);
+        if (!$account) {
+            return [];
+        }
+
+        $cacheKey = self::CACHE_KEY_PREFIX . $store->getId();
+        $cached = $this->cache->load($cacheKey);
+        if ($cached !== false) {
+            return $this->deserializeFormats($this->serializer->unserialize($cached));
+        }
+
+        try {
+            $formats = (new GetSettings($account))->getCurrencyFormats();
+            $this->cache->save(
+                $this->serializer->serialize($this->serializeFormats($formats)),
+                $cacheKey,
+                [],
+                self::CACHE_TTL
+            );
+            return $formats;
+        } catch (Exception $e) {
+            $this->logger->exception($e);
+            return [];
+        }
+    }
+
+    /**
+     * @param Format[] $formats
+     * @return array
+     */
+    private function serializeFormats(array $formats): array
+    {
+        $data = [];
+        foreach ($formats as $code => $format) {
+            $data[$code] = [
+                'currency_before_amount' => $format->getCurrencyBeforeAmount(),
+                'currency_token' => $format->getCurrencyToken(),
+                'decimal_character' => $format->getDecimalCharacter(),
+                'grouping_separator' => $format->getGroupingSeparator(),
+                'decimal_places' => $format->getDecimalPlaces(),
+            ];
+        }
+        return $data;
+    }
+
+    /**
+     * @param array $data
+     * @return Format[]
+     */
+    private function deserializeFormats(array $data): array
+    {
+        $formats = [];
+        foreach ($data as $code => $item) {
+            $formats[$code] = new Format(
+                (bool)$item['currency_before_amount'],
+                $item['currency_token'],
+                $item['decimal_character'],
+                $item['grouping_separator'],
+                (int)$item['decimal_places']
+            );
+        }
+        return $formats;
     }
 
     /**
@@ -242,7 +348,7 @@ class Builder
     private function buildPriceFormatWithSymbol($localeData, $defaultSet)
     {
         if ($localeData['NumberElements'][$defaultSet]['patterns']['currencyFormat']) {
-            return $localeData['NumberElements']['latn']['patterns']['currencyFormat'];
+            return $localeData['NumberElements'][$defaultSet]['patterns']['currencyFormat'];
         }
         return explode(';', $localeData['NumberPatterns'][1])[0];
     }
@@ -258,7 +364,7 @@ class Builder
     private function buildDecimalSymbol($localeData, $defaultSet)
     {
         if ($localeData['NumberElements'][$defaultSet]['symbols']['decimal']) {
-            return $localeData['NumberElements']['latn']['symbols']['decimal'];
+            return $localeData['NumberElements'][$defaultSet]['symbols']['decimal'];
         }
         return $localeData['NumberElements'][0];
     }
@@ -274,7 +380,7 @@ class Builder
     private function buildGroupSymbol($localeData, $defaultSet)
     {
         if ($localeData['NumberElements'][$defaultSet]['symbols']['group']) {
-            return $localeData['NumberElements']['latn']['symbols']['group'];
+            return $localeData['NumberElements'][$defaultSet]['symbols']['group'];
         }
         return $localeData['NumberElements'][1];
     }

--- a/Model/Operation/GetSettings.php
+++ b/Model/Operation/GetSettings.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\Operation;
+
+use Nosto\Model\Format;
+use Nosto\NostoException;
+use Nosto\Operation\AbstractAuthenticatedOperation;
+use Nosto\Request\Api\ApiRequest;
+use Nosto\Request\Api\Token;
+use Nosto\Request\Http\Exception\AbstractHttpException;
+use Nosto\Result\Api\JsonResultHandler;
+use Nosto\Types\Signup\AccountInterface;
+
+class GetSettings extends AbstractAuthenticatedOperation
+{
+    public function __construct(AccountInterface $account, string $activeDomain = '')
+    {
+        parent::__construct($account, $activeDomain);
+    }
+
+    /**
+     * Fetches account settings from Nosto and returns the currencies map as Format objects.
+     *
+     * @return Format[] keyed by currency code
+     * @throws NostoException
+     * @throws AbstractHttpException
+     */
+    public function getCurrencyFormats(): array
+    {
+        $request = $this->initRequest(
+            $this->account->getApiToken(Token::API_SETTINGS),
+            $this->account->getName(),
+            $this->activeDomain
+        );
+        $result = $request->getResultHandler()->parse($request->get());
+
+        if (!is_array($result) || empty($result['currencies'])) {
+            return [];
+        }
+
+        $formats = [];
+        foreach ($result['currencies'] as $code => $data) {
+            if (!isset(
+                $data['currency_before_amount'],
+                $data['currency_token'],
+                $data['decimal_character'],
+                $data['grouping_separator'],
+                $data['decimal_places']
+            )) {
+                continue;
+            }
+            $formats[$code] = new Format(
+                (bool)$data['currency_before_amount'],
+                $data['currency_token'],
+                $data['decimal_character'],
+                $data['grouping_separator'],
+                (int)$data['decimal_places']
+            );
+        }
+
+        return $formats;
+    }
+
+    /** @inheritdoc */
+    protected function getResultHandler()
+    {
+        return new JsonResultHandler();
+    }
+
+    /** @inheritdoc */
+    protected function getRequestType()
+    {
+        return new ApiRequest();
+    }
+
+    /** @inheritdoc */
+    protected function getContentType()
+    {
+        return self::CONTENT_TYPE_APPLICATION_JSON;
+    }
+
+    /** @inheritdoc */
+    protected function getPath()
+    {
+        return ApiRequest::PATH_SETTINGS;
+    }
+}

--- a/Model/Operation/GetSettings.php
+++ b/Model/Operation/GetSettings.php
@@ -63,13 +63,13 @@ class GetSettings extends AbstractAuthenticatedOperation
         );
         $result = $request->getResultHandler()->parse($request->get());
 
-        if (!is_array($result) || empty($result['currencies'])) {
+        if (!is_array($result) || empty($result['currencies']) || !is_array($result['currencies'])) {
             return [];
         }
 
         $formats = [];
         foreach ($result['currencies'] as $code => $data) {
-            if (!isset(
+            if (!is_array($data) || !isset(
                 $data['currency_before_amount'],
                 $data['currency_token'],
                 $data['decimal_character'],

--- a/Model/Operation/GetSettings.php
+++ b/Model/Operation/GetSettings.php
@@ -44,7 +44,6 @@ use Nosto\Request\Api\ApiRequest;
 use Nosto\Request\Api\Token;
 use Nosto\Request\Http\Exception\AbstractHttpException;
 use Nosto\Result\Api\JsonResultHandler;
-use Nosto\Types\Signup\AccountInterface;
 
 class GetSettings extends AbstractAuthenticatedOperation
 {

--- a/Model/Operation/GetSettings.php
+++ b/Model/Operation/GetSettings.php
@@ -48,11 +48,6 @@ use Nosto\Types\Signup\AccountInterface;
 
 class GetSettings extends AbstractAuthenticatedOperation
 {
-    public function __construct(AccountInterface $account, string $activeDomain = '')
-    {
-        parent::__construct($account, $activeDomain);
-    }
-
     /**
      * Fetches account settings from Nosto and returns the currencies map as Format objects.
      *

--- a/Model/Operation/GetSettings.php
+++ b/Model/Operation/GetSettings.php
@@ -48,7 +48,7 @@ use Nosto\Result\Api\JsonResultHandler;
 
 class GetSettings extends AbstractAuthenticatedOperation
 {
-    private const SETTINGS_PATH = '/include/%s/settings.json';
+    private const SETTINGS_PATH = '%s/include/%s/settings.json';
 
     /**
      * Fetches account settings from Nosto and returns the currency settings map as Format objects.
@@ -113,7 +113,7 @@ class GetSettings extends AbstractAuthenticatedOperation
     private function buildSettingsUrl(): string
     {
         return sprintf(
-            '%s' . self::SETTINGS_PATH,
+            self::SETTINGS_PATH,
             $this->getConnectBaseUrl(),
             rawurlencode($this->account->getName())
         );

--- a/Model/Operation/GetSettings.php
+++ b/Model/Operation/GetSettings.php
@@ -73,7 +73,6 @@ class GetSettings extends AbstractAuthenticatedOperation
                 $data['currency_before_amount'],
                 $data['currency_token'],
                 $data['decimal_character'],
-                $data['grouping_separator'],
                 $data['decimal_places']
             )) {
                 continue;
@@ -82,7 +81,7 @@ class GetSettings extends AbstractAuthenticatedOperation
                 (bool)$data['currency_before_amount'],
                 $data['currency_token'],
                 $data['decimal_character'],
-                $data['grouping_separator'],
+                $data['grouping_separator'] ?? null,
                 (int)$data['decimal_places']
             );
         }

--- a/Model/Operation/GetSettings.php
+++ b/Model/Operation/GetSettings.php
@@ -38,55 +38,98 @@
 namespace Nosto\Tagging\Model\Operation;
 
 use Nosto\Model\Format;
-use Nosto\NostoException;
+use Nosto\Exception\Builder as ExceptionBuilder;
+use Nosto\Nosto;
 use Nosto\Operation\AbstractAuthenticatedOperation;
 use Nosto\Request\Api\ApiRequest;
-use Nosto\Request\Api\Token;
 use Nosto\Request\Http\Exception\AbstractHttpException;
+use Nosto\Request\Http\HttpRequest;
 use Nosto\Result\Api\JsonResultHandler;
 
 class GetSettings extends AbstractAuthenticatedOperation
 {
+    private const SETTINGS_PATH = '/include/%s/settings.json';
+
     /**
-     * Fetches account settings from Nosto and returns the currencies map as Format objects.
+     * Fetches account settings from Nosto and returns the currency settings map as Format objects.
      *
      * @return Format[] keyed by currency code
-     * @throws NostoException
      * @throws AbstractHttpException
      */
     public function getCurrencyFormats(): array
     {
-        $request = $this->initRequest(
-            $this->account->getApiToken(Token::API_SETTINGS),
-            $this->account->getName(),
-            $this->activeDomain
-        );
-        $result = $request->getResultHandler()->parse($request->get());
+        $request = new HttpRequest();
+        $request->setUrl($this->buildSettingsUrl());
 
-        if (!is_array($result) || empty($result['currencies']) || !is_array($result['currencies'])) {
+        $response = $request->get();
+        if ($response->getCode() !== 200) {
+            throw ExceptionBuilder::fromHttpRequestAndResponse($request, $response);
+        }
+
+        $result = $response->getJsonResult(true);
+        if (!is_array($result)) {
+            return [];
+        }
+
+        $currencies = $result['currency_settings'] ?? $result['currencySettings'] ?? [];
+        if (!is_array($currencies)) {
             return [];
         }
 
         $formats = [];
-        foreach ($result['currencies'] as $code => $data) {
-            if (!is_array($data) || !isset(
-                $data['currency_before_amount'],
-                $data['currency_token'],
-                $data['decimal_character'],
-                $data['decimal_places']
-            )) {
+        foreach ($currencies as $code => $data) {
+            if (!is_array($data)) {
                 continue;
             }
+
+            $currencyBeforeAmount = $data['currency_before_amount'] ?? $data['currencyBeforeAmount'] ?? null;
+            $currencyToken = $data['currency_token'] ?? $data['currencyToken'] ?? null;
+            $decimalCharacter = $data['decimal_character'] ?? $data['decimalCharacter'] ?? null;
+            $groupingSeparator = $data['grouping_separator'] ?? $data['groupingSeparator'] ?? null;
+            $decimalPlaces = $data['decimal_places'] ?? $data['decimalPlaces'] ?? null;
+            if ($currencyBeforeAmount === null
+                || $currencyToken === null
+                || $decimalCharacter === null
+                || $decimalPlaces === null
+            ) {
+                continue;
+            }
+
             $formats[$code] = new Format(
-                (bool)$data['currency_before_amount'],
-                $data['currency_token'],
-                $data['decimal_character'],
-                $data['grouping_separator'] ?? null,
-                (int)$data['decimal_places']
+                (bool)$currencyBeforeAmount,
+                $currencyToken,
+                $decimalCharacter,
+                $groupingSeparator,
+                (int)$decimalPlaces
             );
         }
 
         return $formats;
+    }
+
+    /**
+     * @return string
+     */
+    private function buildSettingsUrl(): string
+    {
+        return sprintf(
+            '%s' . self::SETTINGS_PATH,
+            $this->getConnectBaseUrl(),
+            rawurlencode($this->account->getName())
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getConnectBaseUrl(): string
+    {
+        $serverUrl = Nosto::getServerUrl();
+        if (strpos($serverUrl, 'http://') === 0 || strpos($serverUrl, 'https://') === 0) {
+            return rtrim($serverUrl, '/');
+        }
+
+        return 'https://' . rtrim($serverUrl, '/');
     }
 
     /** @inheritdoc */

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "php": ">=7.4.0",
     "magento/framework": ">=101.0.6|~104.0",
     "ext-json": "*",
-    "nosto/php-sdk": "^7.7.5",
+    "nosto/php-sdk": "7.7.7",
     "laminas/laminas-uri": "*"
   },
   "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae3211ded75b2a4a3d2282a56f243265",
+    "content-hash": "60644a963f063905627c285fd34a088e",
     "packages": [
         {
             "name": "brick/math",
@@ -2864,16 +2864,16 @@
         },
         {
             "name": "nosto/php-sdk",
-            "version": "7.7.5",
+            "version": "7.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "9d3854ac43460d808216bfb0a1227d97aeb8aa33"
+                "reference": "bfede8a44b11a74a484199bf0982f79bf9da8d12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/9d3854ac43460d808216bfb0a1227d97aeb8aa33",
-                "reference": "9d3854ac43460d808216bfb0a1227d97aeb8aa33",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/bfede8a44b11a74a484199bf0982f79bf9da8d12",
+                "reference": "bfede8a44b11a74a484199bf0982f79bf9da8d12",
                 "shasum": ""
             },
             "require": {
@@ -2913,9 +2913,9 @@
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
             "support": {
                 "issues": "https://github.com/Nosto/nosto-php-sdk/issues",
-                "source": "https://github.com/Nosto/nosto-php-sdk/tree/7.7.5"
+                "source": "https://github.com/Nosto/nosto-php-sdk/tree/7.7.7"
             },
-            "time": "2026-06-10T11:43:54+00:00"
+            "time": "2026-06-22T10:48:58+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

Respect Nosto-configured currency formats instead of overriding them

  Problem

  When Currencies/Builder runs (on settings sync or the daily cron), it derives currency formats entirely from Magento's local ICU locale data and writes them back to Nosto. This silently overwrites any
  currency formats a merchant has deliberately configured in the Nosto dashboard.

  Changes

  Model/Operation/GetSettings.php (new)
  - Implements a GET on the existing /settings API endpoint (same path as UpdateSettings, which uses PUT)
  - Parses the currencies map from the JSON response into Nosto\Model\Format[] keyed by currency code
  - Follows the same AbstractAuthenticatedOperation pattern used by all other SDK operations in this module

  Model/Meta/Account/Settings/Currencies/Builder.php
  - Before building formats from local ICU data, fetches any formats already stored in Nosto via GetSettings
  - In the per-currency loop: if Nosto already has a Format for that code, it is used as-is and the local derivation is skipped; otherwise falls back to the existing ICU-based logic unchanged
  - Fetched formats are cached in Magento's default cache for 1 hour (keyed per store) to avoid an API call on every build() invocation — both populated and empty responses are cached; only transient
  exceptions are not cached, so they are retried on the next call
  - Also fixes a pre-existing bug where buildPriceFormatWithSymbol, buildDecimalSymbol, and buildGroupSymbol checked $defaultSet in the condition but hardcoded 'latn' in the return value, causing
  incorrect formats for non-Latin locales (e.g. Arabic)

Behaviour

|Scenario|Result|
|------|------|
|Nosto has a format for currency X|Nosto's format is used, local ICU data ignored for X|
|Nosto has no format for currency X| Local ICU data used as before|
|No Nosto account for the store|Falls through to local ICU data entirely|
|API call fails|Logged, empty result returned, local ICU data used as before|

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://nostosolutions.atlassian.net/browse/NS-14204

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
