### PR TITLE
Add redirect type 0 so that the direct product URL is used

### DIFF
--- a/Model/Product/Url/Builder.php
+++ b/Model/Product/Url/Builder.php
@@ -89,6 +89,7 @@ class Builder extends DataObject
             UrlRewrite::ENTITY_ID => $product->getId(),
             UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
             UrlRewrite::STORE_ID => $store->getId(),
+            UrlRewrite::REDIRECT_TYPE => 0            
         ];
         $productRequestPath = $product->getData('request_path');
         if (!empty($productRequestPath)) {


### PR DESCRIPTION
Add redirect type 0 so that the direct product URL is used, otherwise it will keep using an old URL key when syncing products.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
