### PR TITLE
Performance/get min price SKU

### DIFF
--- a/Model/Product/Variation/Builder.php
+++ b/Model/Product/Variation/Builder.php
@@ -55,6 +55,7 @@ use Nosto\Tagging\Helper\Currency as CurrencyHelper;
 use Nosto\Tagging\Helper\Price as NostoPriceHelper;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
+use Nosto\Tagging\Model\ResourceModel\Sku as SkuResource;
 
 class Builder
 {
@@ -66,6 +67,7 @@ class Builder
     private RuleResourceModel $ruleResourceModel;
     private NostoProductRepository $nostoProductRepository;
     private TimezoneInterface $localeDate;
+    private SkuResource $skuResource;
 
     /**
      * Builder constructor.
@@ -77,6 +79,7 @@ class Builder
      * @param RuleResourceModel $ruleResourceModel
      * @param NostoProductRepository $nostoProductRepository
      * @param TimezoneInterface $localeDate
+     * @param SkuResource $skuResource
      */
     public function __construct(
         NostoPriceHelper $priceHelper,
@@ -86,7 +89,8 @@ class Builder
         PriceFactory $priceFactory,
         RuleResourceModel $ruleResourceModel,
         NostoProductRepository $nostoProductRepository,
-        TimezoneInterface $localeDate
+        TimezoneInterface $localeDate,
+        SkuResource $skuResource
     ) {
         $this->nostoPriceHelper = $priceHelper;
         $this->logger = $logger;
@@ -96,6 +100,7 @@ class Builder
         $this->ruleResourceModel = $ruleResourceModel;
         $this->nostoProductRepository = $nostoProductRepository;
         $this->localeDate = $localeDate;
+        $this->skuResource = $skuResource;
     }
 
     /**
@@ -194,58 +199,32 @@ class Builder
     /**
      * Returns the SKU|Product object with the lowest price.
      *
+     * Reads final_price from catalog_product_index_price for the given customer group
+     * to identify the cheapest SKU without loading all child product objects.
+     *
      * @param MageProduct $product
      * @param Group $group
      * @param Store $store
      * @return MageProduct
+     * @throws NoSuchEntityException
      */
-    public function getMinPriceSku(Product $product, Group $group, Store $store)
+    public function getMinPriceSku(Product $product, Group $group, Store $store): MageProduct
     {
-        $minPriceSku = [];
         if (!$product->getTypeInstance() instanceof ConfigurableType) {
             return $product;
         }
-        $skus = $this->nostoProductRepository->getSkus($product);
-        if (empty($skus)) {
+        $skuIds = $this->nostoProductRepository->getSkuIds($product);
+        if (empty($skuIds)) {
             return $product;
         }
-        foreach ($skus as $sku) {
-            if (!$sku instanceof MageProduct) {
-                continue;
-            }
-            $skuPrice = $sku->getPrice();
-            $skuRulePrice = $this->ruleResourceModel->getRulePrice(
-                $this->localeDate->scopeDate(),
-                $store->getWebsiteId(),
-                $group->getId(),
-                $sku->getId()
-            );
-            foreach ($sku->getTierPrices() as $tierPrice) {
-                if ((int)$tierPrice->getCustomerGroupId() === (int)$group->getId()) {
-                    $skuTierPrice = $tierPrice->getValue();
-                }
-                break;
-            }
-            // If has a customer group pricing for current group,
-            // check if it's lower than regular SKU price
-            /* @suppress UndeclaredVariable */
-            if (isset($skuTierPrice) && $skuRulePrice !== false) {
-                $skuPrice = min($skuPrice, $skuTierPrice, $skuRulePrice);
-            } elseif (!isset($skuTierPrice) && $skuRulePrice !== false) {
-                $skuPrice = min($skuPrice, $skuRulePrice);
-            } elseif (isset($skuTierPrice) && $skuRulePrice === false) {
-                $skuPrice = min($skuPrice, $skuTierPrice);
-            }
-
-            if (empty($minPriceSku)) { // First loop run
-                $minPriceSku['sku'] = $sku;
-                $minPriceSku['price'] = $skuPrice;
-            } elseif ($skuPrice < $minPriceSku['price']) {
-                $minPriceSku['sku'] = $sku;
-                $minPriceSku['price'] = $skuPrice;
-            }
+        $minPriceSkuId = $this->skuResource->getMinPriceSkuId(
+            $store->getWebsite(),
+            (int)$group->getId(),
+            array_values($skuIds)
+        );
+        if ($minPriceSkuId === null) {
+            return $product;
         }
-        /** @phan-suppress-next-line PhanTypePossiblyInvalidDimOffset */
-        return $minPriceSku['sku'];
+        return $this->nostoProductRepository->reloadProduct($minPriceSkuId, (int)$store->getId());
     }
 }

--- a/Model/Product/Variation/Builder.php
+++ b/Model/Product/Variation/Builder.php
@@ -223,8 +223,52 @@ class Builder
             array_values($skuIds)
         );
         if ($minPriceSkuId === null) {
-            return $product;
+            return $this->getMinPriceSkuFallback($product, $group, $store);
         }
         return $this->nostoProductRepository->reloadProduct($minPriceSkuId, (int)$store->getId());
+    }
+
+    /**
+     * Fallback when the price index has no rows for the requested website/customer group.
+     * Loads in-stock child product models and picks the one with the lowest effective price
+     * (base price, catalog rule price, and customer-group tier price all considered).
+     *
+     * @param MageProduct $product
+     * @param Group $group
+     * @param Store $store
+     * @return MageProduct
+     * @throws NoSuchEntityException
+     */
+    private function getMinPriceSkuFallback(Product $product, Group $group, Store $store): MageProduct
+    {
+        $skus = $this->nostoProductRepository->getInStockSkuProducts($product, $store);
+        if (empty($skus)) {
+            return $product;
+        }
+        $minPriceSku = null;
+        $minPrice = PHP_INT_MAX;
+        foreach ($skus as $sku) {
+            $skuPrice = (float)$sku->getPrice();
+            foreach ($sku->getTierPrices() as $tierPrice) {
+                if ((int)$tierPrice->getCustomerGroupId() === (int)$group->getId()) {
+                    $skuPrice = min($skuPrice, (float)$tierPrice->getValue());
+                    break;
+                }
+            }
+            $rulePrice = $this->ruleResourceModel->getRulePrice(
+                $this->localeDate->scopeDate(),
+                $store->getWebsiteId(),
+                $group->getId(),
+                $sku->getId()
+            );
+            if ($rulePrice !== false) {
+                $skuPrice = min($skuPrice, (float)$rulePrice);
+            }
+            if ($skuPrice < $minPrice) {
+                $minPrice = $skuPrice;
+                $minPriceSku = $sku;
+            }
+        }
+        return $minPriceSku ?? $product;
     }
 }

--- a/Model/ResourceModel/Sku.php
+++ b/Model/ResourceModel/Sku.php
@@ -65,6 +65,35 @@ class Sku extends ProductResource
     }
 
     /**
+     * Returns the entity_id of the child SKU with the lowest final_price for the given
+     * customer group by reading directly from the price index — no product model load.
+     *
+     * @param Website $website
+     * @param int $customerGroupId
+     * @param array $skuIds
+     * @return int|null
+     */
+    public function getMinPriceSkuId(Website $website, int $customerGroupId, array $skuIds): ?int
+    {
+        if (empty($skuIds)) {
+            return null;
+        }
+        $connection = $this->_resource->getConnection();
+        $select = $connection->select()
+            ->from(
+                ["cpip" => $this->_resource->getTableName(self::CATALOG_PRODUCT_PRICE_INDEX_TABLE)],
+                ['entity_id']
+            )
+            ->where("cpip.website_id = ?", $website->getId())
+            ->where("cpip.entity_id IN(?)", $skuIds)
+            ->where("cpip.customer_group_id = ?", $customerGroupId)
+            ->order("cpip.final_price ASC")
+            ->limit(1);
+        $result = $connection->fetchOne($select);
+        return $result !== false ? (int)$result : null;
+    }
+
+    /**
      * Builder for the select statement
      *
      * @param Website $website

--- a/Test/Unit/Model/Product/Variation/BuilderTest.php
+++ b/Test/Unit/Model/Product/Variation/BuilderTest.php
@@ -1,0 +1,335 @@
+<?php
+
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nosto\Tagging\Test\Unit\Model\Product\Variation;
+
+use Magento\Catalog\Api\Data\ProductTierPriceInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Type\Simple as SimpleType;
+use Magento\CatalogRule\Model\ResourceModel\Rule as RuleResourceModel;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
+use Magento\Customer\Model\Data\Group;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\Website;
+use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
+use Nosto\Tagging\Model\Product\Variation\Builder;
+use Nosto\Tagging\Model\ResourceModel\Sku as SkuResource;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class BuilderTest extends TestCase
+{
+    /** @var Builder|MockObject */
+    private Builder $builder;
+
+    /** @var NostoProductRepository|MockObject */
+    private MockObject $nostoProductRepositoryMock;
+
+    /** @var SkuResource|MockObject */
+    private MockObject $skuResourceMock;
+
+    /** @var RuleResourceModel|MockObject */
+    private MockObject $ruleResourceModelMock;
+
+    /** @var TimezoneInterface|MockObject */
+    private MockObject $localeDateMock;
+
+    /** @var Product|MockObject */
+    private MockObject $productMock;
+
+    /** @var Store|MockObject */
+    private MockObject $storeMock;
+
+    /** @var Group|MockObject */
+    private MockObject $groupMock;
+
+    /** @var Website|MockObject */
+    private MockObject $websiteMock;
+
+    protected function setUp(): void
+    {
+        // Builder has a generated factory in its constructor that doesn't exist on disk.
+        // Bypass the constructor and inject only the properties that getMinPriceSku() reads.
+        $this->builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $this->nostoProductRepositoryMock = $this->createMock(NostoProductRepository::class);
+        $this->skuResourceMock = $this->getMockBuilder(SkuResource::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->ruleResourceModelMock = $this->createMock(RuleResourceModel::class);
+        $this->localeDateMock = $this->createMock(TimezoneInterface::class);
+
+        $this->injectProperty('nostoProductRepository', $this->nostoProductRepositoryMock);
+        $this->injectProperty('skuResource', $this->skuResourceMock);
+        $this->injectProperty('ruleResourceModel', $this->ruleResourceModelMock);
+        $this->injectProperty('localeDate', $this->localeDateMock);
+
+        $this->websiteMock = $this->createMock(Website::class);
+
+        $this->storeMock = $this->createMock(Store::class);
+        $this->storeMock->method('getWebsite')->willReturn($this->websiteMock);
+        $this->storeMock->method('getId')->willReturn('1');
+        $this->storeMock->method('getWebsiteId')->willReturn('1');
+
+        $this->groupMock = $this->createMock(Group::class);
+        $this->groupMock->method('getId')->willReturn('2');
+
+        $this->productMock = $this->createMock(Product::class);
+    }
+
+    /**
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuReturnsProductWhenNotConfigurable(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(SimpleType::class));
+
+        $this->nostoProductRepositoryMock->expects($this->never())->method('getSkuIds');
+
+        $result = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $this->groupMock,
+            $this->storeMock
+        );
+
+        $this->assertSame($this->productMock, $result);
+    }
+
+    /**
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuReturnsProductWhenNoSkuIds(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')->willReturn([]);
+        $this->skuResourceMock->expects($this->never())->method('getMinPriceSkuId');
+
+        $result = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $this->groupMock,
+            $this->storeMock
+        );
+
+        $this->assertSame($this->productMock, $result);
+    }
+
+    /**
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuReturnsCheapestSku(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20, 30 => 30]);
+
+        $this->skuResourceMock->method('getMinPriceSkuId')
+            ->with($this->websiteMock, 2, [10, 20, 30])
+            ->willReturn(20);
+
+        $cheapestSku = $this->createMock(Product::class);
+        $this->nostoProductRepositoryMock->method('reloadProduct')
+            ->with(20, 1)
+            ->willReturn($cheapestSku);
+
+        $result = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $this->groupMock,
+            $this->storeMock
+        );
+
+        $this->assertSame($cheapestSku, $result);
+    }
+
+    /**
+     * Index returns null and no in-stock children exist — parent product is returned.
+     *
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuFallsBackToParentWhenIndexMissingAndNoChildren(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20]);
+        $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(null);
+        $this->nostoProductRepositoryMock->method('getInStockSkuProducts')->willReturn([]);
+
+        $this->nostoProductRepositoryMock->expects($this->never())->method('reloadProduct');
+
+        $result = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $this->groupMock,
+            $this->storeMock
+        );
+
+        $this->assertSame($this->productMock, $result);
+    }
+
+    /**
+     * Index returns null but in-stock children exist — picks the child with the lowest base price.
+     *
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuFallbackPicksCheapestChildByBasePrice(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20]);
+        $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(null);
+
+        $expensiveSku = $this->buildChildProductMock(50.0, [], false);
+        $cheapestSku  = $this->buildChildProductMock(30.0, [], false);
+
+        $this->nostoProductRepositoryMock->method('getInStockSkuProducts')
+            ->willReturn([$expensiveSku, $cheapestSku]);
+
+        $result = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $this->groupMock,
+            $this->storeMock
+        );
+
+        $this->assertSame($cheapestSku, $result);
+    }
+
+    /**
+     * Fallback picks the child with the lowest effective price after applying a catalog rule.
+     *
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuFallbackAppliesCatalogRulePrice(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20]);
+        $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(null);
+
+        // SKU A: base price 50, catalog rule brings it to 25
+        $skuA = $this->buildChildProductMock(50.0, [], 25.0);
+        // SKU B: base price 40, no catalog rule
+        $skuB = $this->buildChildProductMock(40.0, [], false);
+
+        $this->nostoProductRepositoryMock->method('getInStockSkuProducts')
+            ->willReturn([$skuA, $skuB]);
+
+        $result = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $this->groupMock,
+            $this->storeMock
+        );
+
+        $this->assertSame($skuA, $result);
+    }
+
+    /**
+     * Fallback applies the tier price for the customer group when it is lower than the base price.
+     *
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuFallbackAppliesTierPriceForGroup(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20]);
+        $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(null);
+
+        // SKU A: base price 60, group-2 tier price 20
+        $tierPrice = $this->createMock(ProductTierPriceInterface::class);
+        $tierPrice->method('getCustomerGroupId')->willReturn('2');
+        $tierPrice->method('getValue')->willReturn(20.0);
+
+        $skuA = $this->buildChildProductMock(60.0, [$tierPrice], false);
+        // SKU B: base price 35, no discounts
+        $skuB = $this->buildChildProductMock(35.0, [], false);
+
+        $this->nostoProductRepositoryMock->method('getInStockSkuProducts')
+            ->willReturn([$skuA, $skuB]);
+
+        $result = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $this->groupMock,
+            $this->storeMock
+        );
+
+        $this->assertSame($skuA, $result);
+    }
+
+    /**
+     * @param float $price
+     * @param ProductTierPriceInterface[] $tierPrices
+     * @param float|false $rulePrice
+     * @return Product|MockObject
+     */
+    private function buildChildProductMock(float $price, array $tierPrices, $rulePrice): MockObject
+    {
+        $sku = $this->createMock(Product::class);
+        $sku->method('getPrice')->willReturn($price);
+        $sku->method('getTierPrices')->willReturn($tierPrices);
+
+        $this->ruleResourceModelMock
+            ->method('getRulePrice')
+            ->willReturn($rulePrice);
+
+        return $sku;
+    }
+
+    private function injectProperty(string $name, object $value): void
+    {
+        $property = new ReflectionProperty(Builder::class, $name);
+        $property->setAccessible(true);
+        $property->setValue($this->builder, $value);
+    }
+}

--- a/Test/Unit/Model/Product/Variation/BuilderTest.php
+++ b/Test/Unit/Model/Product/Variation/BuilderTest.php
@@ -105,6 +105,11 @@ class BuilderTest extends TestCase
         $this->injectProperty('ruleResourceModel', $this->ruleResourceModelMock);
         $this->injectProperty('localeDate', $this->localeDateMock);
 
+        // Align with the production contract: getRulePrice() returns false when no rule applies.
+        // An unconfigured mock returns null, which would be misread as a 0.0 rule price.
+        $this->ruleResourceModelMock->method('getRulePrice')->willReturn(false);
+        $this->localeDateMock->method('scopeDate')->willReturn(new \DateTime());
+
         $this->websiteMock = $this->createMock(Website::class);
 
         $this->storeMock = $this->createMock(Store::class);
@@ -226,8 +231,8 @@ class BuilderTest extends TestCase
             ->willReturn([10 => 10, 20 => 20]);
         $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(null);
 
-        $expensiveSku = $this->buildChildProductMock(50.0, [], false);
-        $cheapestSku  = $this->buildChildProductMock(30.0, [], false);
+        $expensiveSku = $this->buildChildProductMock(101, 50.0, []);
+        $cheapestSku  = $this->buildChildProductMock(102, 30.0, []);
 
         $this->nostoProductRepositoryMock->method('getInStockSkuProducts')
             ->willReturn([$expensiveSku, $cheapestSku]);
@@ -243,6 +248,8 @@ class BuilderTest extends TestCase
 
     /**
      * Fallback picks the child with the lowest effective price after applying a catalog rule.
+     * SKU A has base price 50 but a catalog rule brings its effective price to 25.
+     * SKU B has base price 40 and no rule. SKU A should win.
      *
      * @covers Builder::getMinPriceSku()
      */
@@ -255,10 +262,17 @@ class BuilderTest extends TestCase
             ->willReturn([10 => 10, 20 => 20]);
         $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(null);
 
-        // SKU A: base price 50, catalog rule brings it to 25
-        $skuA = $this->buildChildProductMock(50.0, [], 25.0);
-        // SKU B: base price 40, no catalog rule
-        $skuB = $this->buildChildProductMock(40.0, [], false);
+        $skuA = $this->buildChildProductMock(101, 50.0, []);
+        $skuB = $this->buildChildProductMock(102, 40.0, []);
+
+        // Re-inject a fresh mock so the setUp default stub does not stack as a prior
+        // invocation and interfere with the per-SKU callback.
+        $ruleMock = $this->createMock(RuleResourceModel::class);
+        $ruleMock->method('getRulePrice')
+            ->willReturnCallback(function ($date, $websiteId, $groupId, $skuId) {
+                return $skuId === 101 ? 25.0 : false;
+            });
+        $this->injectProperty('ruleResourceModel', $ruleMock);
 
         $this->nostoProductRepositoryMock->method('getInStockSkuProducts')
             ->willReturn([$skuA, $skuB]);
@@ -274,6 +288,8 @@ class BuilderTest extends TestCase
 
     /**
      * Fallback applies the tier price for the customer group when it is lower than the base price.
+     * SKU A has base price 60 but a group-2 tier price of 20, making its effective price 20.
+     * SKU B has base price 35 and no discounts. SKU A should win.
      *
      * @covers Builder::getMinPriceSku()
      */
@@ -286,14 +302,12 @@ class BuilderTest extends TestCase
             ->willReturn([10 => 10, 20 => 20]);
         $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(null);
 
-        // SKU A: base price 60, group-2 tier price 20
         $tierPrice = $this->createMock(ProductTierPriceInterface::class);
         $tierPrice->method('getCustomerGroupId')->willReturn('2');
         $tierPrice->method('getValue')->willReturn(20.0);
 
-        $skuA = $this->buildChildProductMock(60.0, [$tierPrice], false);
-        // SKU B: base price 35, no discounts
-        $skuB = $this->buildChildProductMock(35.0, [], false);
+        $skuA = $this->buildChildProductMock(101, 60.0, [$tierPrice]);
+        $skuB = $this->buildChildProductMock(102, 35.0, []);
 
         $this->nostoProductRepositoryMock->method('getInStockSkuProducts')
             ->willReturn([$skuA, $skuB]);
@@ -308,21 +322,17 @@ class BuilderTest extends TestCase
     }
 
     /**
+     * @param int $id
      * @param float $price
      * @param ProductTierPriceInterface[] $tierPrices
-     * @param float|false $rulePrice
      * @return Product|MockObject
      */
-    private function buildChildProductMock(float $price, array $tierPrices, $rulePrice): MockObject
+    private function buildChildProductMock(int $id, float $price, array $tierPrices): MockObject
     {
         $sku = $this->createMock(Product::class);
+        $sku->method('getId')->willReturn($id);
         $sku->method('getPrice')->willReturn($price);
         $sku->method('getTierPrices')->willReturn($tierPrices);
-
-        $this->ruleResourceModelMock
-            ->method('getRulePrice')
-            ->willReturn($rulePrice);
-
         return $sku;
     }
 

--- a/Test/Unit/Model/ResourceModel/SkuTest.php
+++ b/Test/Unit/Model/ResourceModel/SkuTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nosto\Tagging\Test\Unit\Model\ResourceModel;
+
+use Magento\Eav\Model\Entity\AbstractEntity;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Store\Model\Website;
+use Nosto\Tagging\Model\ResourceModel\Sku;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SkuTest extends TestCase
+{
+    /** @var Sku|MockObject */
+    private Sku $sku;
+
+    /** @var ResourceConnection|MockObject */
+    private MockObject $resourceConnectionMock;
+
+    /** @var AdapterInterface|MockObject */
+    private MockObject $connectionMock;
+
+    /** @var Select|MockObject */
+    private MockObject $selectMock;
+
+    /** @var Website|MockObject */
+    private MockObject $websiteMock;
+
+    protected function setUp(): void
+    {
+        $this->sku = $this->getMockBuilder(Sku::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $this->selectMock = $this->createMock(Select::class);
+        $this->selectMock->method('from')->willReturnSelf();
+        $this->selectMock->method('where')->willReturnSelf();
+        $this->selectMock->method('order')->willReturnSelf();
+        $this->selectMock->method('limit')->willReturnSelf();
+
+        $this->connectionMock = $this->createMock(AdapterInterface::class);
+        $this->connectionMock->method('select')->willReturn($this->selectMock);
+
+        $this->resourceConnectionMock = $this->createMock(ResourceConnection::class);
+        $this->resourceConnectionMock->method('getConnection')->willReturn($this->connectionMock);
+        $this->resourceConnectionMock->method('getTableName')
+            ->willReturn(Sku::CATALOG_PRODUCT_PRICE_INDEX_TABLE);
+
+        $resourceProperty = new \ReflectionProperty(AbstractEntity::class, '_resource');
+        $resourceProperty->setAccessible(true);
+        $resourceProperty->setValue($this->sku, $this->resourceConnectionMock);
+
+        $this->websiteMock = $this->createMock(Website::class);
+        $this->websiteMock->method('getId')->willReturn('1');
+    }
+
+    /**
+     * @covers Sku::getMinPriceSkuId()
+     */
+    public function testGetMinPriceSkuIdReturnsNullForEmptySkuIds(): void
+    {
+        $this->connectionMock->expects($this->never())->method('fetchOne');
+
+        $result = $this->sku->getMinPriceSkuId($this->websiteMock, 1, []);
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * @covers Sku::getMinPriceSkuId()
+     */
+    public function testGetMinPriceSkuIdReturnsEntityIdWhenFound(): void
+    {
+        $this->connectionMock->method('fetchOne')->willReturn('42');
+
+        $result = $this->sku->getMinPriceSkuId($this->websiteMock, 1, [10, 20, 30]);
+
+        $this->assertSame(42, $result);
+    }
+
+    /**
+     * @covers Sku::getMinPriceSkuId()
+     */
+    public function testGetMinPriceSkuIdReturnsNullWhenNoIndexRow(): void
+    {
+        $this->connectionMock->method('fetchOne')->willReturn(false);
+
+        $result = $this->sku->getMinPriceSkuId($this->websiteMock, 1, [10, 20, 30]);
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Goal: Optimize the minimum-price SKU lookup for configurable products by replacing an in-memory computation with a direct database query against the price index.

  What changed

  Model/ResourceModel/Sku.php
  - Added a new method getMinPriceSkuId(Website, int, array): ?int that queries catalog_product_index_price directly.
  - The query filters by website_id, entity_id IN(...), and customer_group_id, orders by final_price ASC, and returns the single cheapest SKU's entity_id — no product model loading involved.

  Model/Product/Variation/Builder.php
  - Injected SkuResource via the constructor.
  - Rewrote getMinPriceSku() to use the new indexed query instead of loading all child product objects and iterating over them to compute prices manually.
  - The old logic loaded each child MageProduct, then manually compared base price, catalog rule price (ruleResourceModel->getRulePrice()), and tier prices for the customer group — this was O(N) product
  loads plus rule + tier price checks per SKU.
  - The new logic calls nostoProductRepository->getSkuIds() (IDs only, no full loads), queries the index for the cheapest ID, then loads just that one product via nostoProductRepository->reloadProduct().

  Performance impact

  - Eliminates N full child-product model loads (one per variant) when determining the cheapest SKU.
  - Replaces per-SKU catalog rule and tier price lookups with a single SQL query to the Magento price index, which already has final_price materialized for each customer group.
  - Only one product model is loaded at the end (the winner).


Probably for a follow-up:

getMinPriceSkuId queries entity_id IN(?) for all SKU IDs, ordered by final_price ASC, LIMIT 1. If 3 of 5 children are indexed, it silently returns the cheapest of those 3 — no indication that 2
  candidates were skipped. The un-indexed SKUs could be cheaper. The query doesn't distinguish "missing from index" from "doesn't exist".

  Whether to fall back:

  Detecting partial coverage requires knowing how many SKUs should be in the index vs. how many are. A disabled product is legitimately absent, so falling back when any SKU is missing would trigger the
  slow path unnecessarily for stores with disabled variants.

  The practical answer: for the specific use case of new/recently-changed SKUs before reindex, this is a real gap, but it's transient and self-correcting once the index catches up. The original
  implementation had the opposite problem — it was always correct but always slow. Whether partial-coverage detection is worth the extra complexity depends on how often this store sees mid-index states
  and how many variants configurable products typically have.

  If you want to add it, the lightest-weight approach would be to modify getMinPriceSkuId to also return the count of indexed rows found, then fall back in Builder if that count is less than the total
  SKU count — no extra query needed since the index hit is already a single SELECT. But I'd treat this as a follow-up rather than in-scope for this PR, since the primary regression (returning the parent
  always on stale index) is now fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://nostosolutions.atlassian.net/browse/NS-14032

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Why getMinPriceSku requires a full product load per variant rather than reading from catalog_product_index_price. A 35-variant product should not cost 9 seconds. (from the attached document in the linked JIRA)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
