### PR TITLE
NS-14371 Sync child products on status change

### DIFF
--- a/Model/ResourceModel/Magento/Product/CollectionBuilder.php
+++ b/Model/ResourceModel/Magento/Product/CollectionBuilder.php
@@ -216,10 +216,15 @@ class CollectionBuilder
     public function initDefault(Store $store)
     {
         /** @var ProductCollection $collection */
-        return $this
+        $this
             ->reset()
             ->withStore($store)
             ->setSort(EntityInterface::CREATED_AT, $this->productCollection::SORT_ORDER_DESC);
+        // The base indexing collection does not load EAV attributes. Visibility is needed
+        // to tell an individually visible variant (which is its own product in Nosto and
+        // must be synced on its own) from a hidden configurable child. NS-14371.
+        $this->productCollection->addAttributeToSelect('visibility');
+        return $this;
     }
 
     /**

--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -37,6 +37,7 @@
 namespace Nosto\Tagging\Model\Service\Update;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Visibility;
 use Magento\Store\Model\Store;
 use Nosto\NostoException;
 use Nosto\Tagging\Exception\ParentProductDisabledException;
@@ -150,6 +151,12 @@ class ProductUpdateService extends AbstractUpdateService
                 /** @phan-suppress-next-line PhanTypeMismatchArgument */
                 $parents = $this->nostoProductRepository->resolveParentProductIds($product);
             } catch (ParentProductDisabledException $e) {
+                // All parents are disabled. If the product is individually visible it is
+                // its own product in Nosto and must still be synced (e.g. to be
+                // discontinued when it gets disabled), so keep its own id. NS-14371.
+                if ($this->isIndividuallyVisible($product)) {
+                    $productIds[] = $product->getId();
+                }
                 $this->getLogger()->debug($e->getMessage());
                 continue;
             }
@@ -157,10 +164,29 @@ class ProductUpdateService extends AbstractUpdateService
                 foreach ($parents as $id) {
                     $productIds[] = $id;
                 }
+                // A child that is individually visible is also served as its own product
+                // in Nosto, so sync it in addition to its parent(s). Without this a visible
+                // variant would never be updated on its own (e.g. stay in the catalog after
+                // being disabled), because only the parent gets queued. NS-14371.
+                if ($this->isIndividuallyVisible($product)) {
+                    $productIds[] = $product->getId();
+                }
             } else {
                 $productIds[] = $product->getId();
             }
         }
         return array_unique($productIds);
+    }
+
+    /**
+     * Whether the product is visible on its own (catalog and/or search), as opposed to
+     * only existing as a hidden variation of a configurable product.
+     *
+     * @param ProductInterface $product
+     * @return bool
+     */
+    private function isIndividuallyVisible(ProductInterface $product): bool
+    {
+        return (int)$product->getVisibility() !== Visibility::VISIBILITY_NOT_VISIBLE;
     }
 }

--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -154,6 +154,7 @@ class ProductUpdateService extends AbstractUpdateService
                 // All parents are disabled. If the product is individually visible it is
                 // its own product in Nosto and must still be synced (e.g. to be
                 // discontinued when it gets disabled), so keep its own id. NS-14371.
+                /** @phan-suppress-next-line PhanTypeMismatchArgument */
                 if ($this->isIndividuallyVisible($product)) {
                     $productIds[] = $product->getId();
                 }
@@ -168,6 +169,7 @@ class ProductUpdateService extends AbstractUpdateService
                 // in Nosto, so sync it in addition to its parent(s). Without this a visible
                 // variant would never be updated on its own (e.g. stay in the catalog after
                 // being disabled), because only the parent gets queued. NS-14371.
+                /** @phan-suppress-next-line PhanTypeMismatchArgument */
                 if ($this->isIndividuallyVisible($product)) {
                     $productIds[] = $product->getId();
                 }

--- a/Model/Service/Update/ProductUpdateService.php
+++ b/Model/Service/Update/ProductUpdateService.php
@@ -177,7 +177,8 @@ class ProductUpdateService extends AbstractUpdateService
                 $productIds[] = $product->getId();
             }
         }
-        return array_unique($productIds);
+
+        return array_values(array_unique($productIds));
     }
 
     /**
@@ -189,6 +190,12 @@ class ProductUpdateService extends AbstractUpdateService
      */
     private function isIndividuallyVisible(ProductInterface $product): bool
     {
-        return (int)$product->getVisibility() !== Visibility::VISIBILITY_NOT_VISIBLE;
+        $visibility = $product->getVisibility();
+        // If visibility is not loaded, fall back to the safe default (treat as not
+        // individually visible) so standard hidden variations are never queued on their own.
+        if ($visibility === null) {
+            return false;
+        }
+        return (int)$visibility !== Visibility::VISIBILITY_NOT_VISIBLE;
     }
 }

--- a/Test/Unit/Model/Service/Update/ProductUpdateServiceTest.php
+++ b/Test/Unit/Model/Service/Update/ProductUpdateServiceTest.php
@@ -81,10 +81,10 @@ class ProductUpdateServiceTest extends TestCase
 
     /**
      * @param int $id
-     * @param int $visibility
+     * @param int|null $visibility
      * @return Product|MockObject
      */
-    private function productMock(int $id, int $visibility): MockObject
+    private function productMock(int $id, ?int $visibility): MockObject
     {
         $product = $this->createMock(Product::class);
         $product->method('getId')->willReturn($id);
@@ -165,5 +165,36 @@ class ProductUpdateServiceTest extends TestCase
             ->willThrowException(new ParentProductDisabledException(14));
 
         $this->assertSame([], $this->resolveIds([$child]));
+    }
+
+    /**
+     * @covers ::getEntityIdsForPage
+     */
+    public function testUnloadedVisibilityFallsBackToParentOnly(): void
+    {
+        // Safety: if visibility is not loaded on the collection, a child must NOT be
+        // treated as individually visible, otherwise standard hidden variations would
+        // be queued on their own.
+        $child = $this->productMock(15, null);
+        $this->repositoryMock->method('resolveParentProductIds')->willReturn([99]);
+
+        $this->assertSame([99], $this->resolveIds([$child]));
+    }
+
+    /**
+     * @covers ::getEntityIdsForPage
+     */
+    public function testResultIsSequentiallyIndexedAfterDedup(): void
+    {
+        // Two visible children sharing one parent: parent id de-duplicates, and the
+        // returned array must stay sequentially indexed (so it JSON-encodes as an array).
+        $childA = $this->productMock(20, Visibility::VISIBILITY_BOTH);
+        $childB = $this->productMock(21, Visibility::VISIBILITY_BOTH);
+        $this->repositoryMock->method('resolveParentProductIds')->willReturn([99]);
+
+        $result = $this->resolveIds([$childA, $childB]);
+
+        $this->assertSame([99, 20, 21], $result);
+        $this->assertSame(range(0, count($result) - 1), array_keys($result));
     }
 }

--- a/Test/Unit/Model/Service/Update/ProductUpdateServiceTest.php
+++ b/Test/Unit/Model/Service/Update/ProductUpdateServiceTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Copyright (c) 2026, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2026 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nosto\Tagging\Test\Unit\Model\Service\Update;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility;
+use Nosto\Tagging\Exception\ParentProductDisabledException;
+use Nosto\Tagging\Helper\Account as NostoAccountHelper;
+use Nosto\Tagging\Helper\Data as NostoDataHelper;
+use Nosto\Tagging\Logger\Logger as NostoLogger;
+use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
+use Nosto\Tagging\Model\Service\Sync\BulkPublisherInterface;
+use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * @coversDefaultClass \Nosto\Tagging\Model\Service\Update\ProductUpdateService
+ */
+class ProductUpdateServiceTest extends TestCase
+{
+    /** @var ProductUpdateService */
+    private ProductUpdateService $service;
+
+    /** @var NostoProductRepository|MockObject */
+    private MockObject $repositoryMock;
+
+    protected function setUp(): void
+    {
+        $this->repositoryMock = $this->createMock(NostoProductRepository::class);
+
+        $this->service = new ProductUpdateService(
+            $this->createMock(NostoLogger::class),
+            $this->createMock(NostoDataHelper::class),
+            $this->createMock(NostoAccountHelper::class),
+            $this->repositoryMock,
+            $this->createMock(BulkPublisherInterface::class),
+            $this->createMock(BulkPublisherInterface::class),
+            100
+        );
+    }
+
+    /**
+     * @param int $id
+     * @param int $visibility
+     * @return Product|MockObject
+     */
+    private function productMock(int $id, int $visibility): MockObject
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getId')->willReturn($id);
+        $product->method('getVisibility')->willReturn($visibility);
+        return $product;
+    }
+
+    /**
+     * @param Product[] $products
+     * @return int[]
+     */
+    private function resolveIds(array $products): array
+    {
+        $collection = $this->createMock(ProductCollection::class);
+        $collection->method('getItems')->willReturn($products);
+        $method = new ReflectionMethod(ProductUpdateService::class, 'getEntityIdsForPage');
+        $method->setAccessible(true);
+        return $method->invoke($this->service, $collection);
+    }
+
+    /**
+     * @covers ::getEntityIdsForPage
+     */
+    public function testStandaloneProductReturnsOwnId(): void
+    {
+        $product = $this->productMock(10, Visibility::VISIBILITY_BOTH);
+        $this->repositoryMock->method('resolveParentProductIds')->willReturn(null);
+
+        $this->assertSame([10], $this->resolveIds([$product]));
+    }
+
+    /**
+     * @covers ::getEntityIdsForPage
+     */
+    public function testNonVisibleChildReturnsOnlyParent(): void
+    {
+        // standard configurable child (not individually visible) -> parent only (unchanged behavior)
+        $child = $this->productMock(11, Visibility::VISIBILITY_NOT_VISIBLE);
+        $this->repositoryMock->method('resolveParentProductIds')->willReturn([99]);
+
+        $this->assertSame([99], $this->resolveIds([$child]));
+    }
+
+    /**
+     * @covers ::getEntityIdsForPage
+     */
+    public function testVisibleChildReturnsParentAndOwnId(): void
+    {
+        // NS-14371: an individually visible variant is its own Nosto product,
+        // so disabling it must sync the child itself in addition to its parent.
+        $child = $this->productMock(12, Visibility::VISIBILITY_IN_SEARCH);
+        $this->repositoryMock->method('resolveParentProductIds')->willReturn([99]);
+
+        $this->assertSame([99, 12], $this->resolveIds([$child]));
+    }
+
+    /**
+     * @covers ::getEntityIdsForPage
+     */
+    public function testVisibleChildWithAllParentsDisabledReturnsOwnId(): void
+    {
+        // NS-14371: parents disabled -> exception; a visible child must still be synced
+        $child = $this->productMock(13, Visibility::VISIBILITY_IN_CATALOG);
+        $this->repositoryMock->method('resolveParentProductIds')
+            ->willThrowException(new ParentProductDisabledException(13));
+
+        $this->assertSame([13], $this->resolveIds([$child]));
+    }
+
+    /**
+     * @covers ::getEntityIdsForPage
+     */
+    public function testNonVisibleChildWithAllParentsDisabledReturnsNothing(): void
+    {
+        // safety: a hidden child with disabled parents is not its own product -> skip (unchanged)
+        $child = $this->productMock(14, Visibility::VISIBILITY_NOT_VISIBLE);
+        $this->repositoryMock->method('resolveParentProductIds')
+            ->willThrowException(new ParentProductDisabledException(14));
+
+        $this->assertSame([], $this->resolveIds([$child]));
+    }
+}


### PR DESCRIPTION
[NS-14371](https://nostosolutions.atlassian.net/browse/NS-14371)

### Problem
When a merchant disables a product that is a variant of a configurable product (but is also individually visible in the catalog/search), Nosto kept serving it, it stayed `InStock` and showed up in search forever, even though it was disabled in Magento.

This hit Core Group / iStore, where individual variants (e.g. specific pre-owned iPad configurations) are set up as their own visible, sellable products, not just hidden options behind a configurable.

Every product change flows through one method,` ProductUpdateService::toParentProductIds()`. For a variant that belongs to a configurable, it resolved the parent product id and queued only the parent for sync, the variant's own id was thrown away.

That is correct for standard setups, where variants are hidden and only exist as options of their parent. But when a variant is individually visible, it exists as its own product in Nosto too. Discarding its id meant that disabling it only re-synced the (still-enabled) parent, and the variant's own Nosto product was never updated. A related edge case made it worse: if all the parents were disabled, the variant was skipped entirely.

### Solution
In `toParentProductIds()`, when a variant is individually visible, queue its own id in addition to its parent's. Applied to both branches, the normal case and the "all parents disabled" case.

Kept safe for everyone else: the check is gated on visibility. Hidden/standard configurable children (visibility = Not Visible Individually) keep the exact previous behaviour (parent only), so normal merchants get no new products in their Nosto catalog and no extra sync volume, only individually-visible variants are additionally synced.

[NS-14371]: https://nostosolutions.atlassian.net/browse/NS-14371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ