### PR TITLE
NS-14032 Performance improvement

### DIFF
--- a/Model/Product/Variation/Builder.php
+++ b/Model/Product/Variation/Builder.php
@@ -244,7 +244,7 @@ class Builder
             return $this->getMinPriceSkuFallback($product, $group, $store);
         }
         $cacheKey = $minPriceSkuId . ':' . (int)$store->getId();
-        if (!array_key_exists($cacheKey, $reloadedSkuCache)) {
+        if (!isset($reloadedSkuCache[$cacheKey])) {
             $reloadedSkuCache[$cacheKey] = $this->nostoProductRepository->reloadProduct(
                 $minPriceSkuId,
                 (int)$store->getId()

--- a/Model/Product/Variation/Builder.php
+++ b/Model/Product/Variation/Builder.php
@@ -108,19 +108,21 @@ class Builder
      * @param NostoProduct $nostoProduct
      * @param Store $store
      * @param Group $group
+     * @param array $reloadedSkuCache
      * @return Variation
      */
     public function build(
         Product $product,
         NostoProduct $nostoProduct,
         Store $store,
-        Group $group
+        Group $group,
+        array &$reloadedSkuCache = []
     ) {
         $variation = new Variation();
         try {
             $variation->setVariationId($group->getCode());
             $variation->setAvailability($nostoProduct->getAvailability());
-            $variation->setPrice($this->getLowestVariationPrice($product, $group, $store));
+            $variation->setPrice($this->getLowestVariationPrice($product, $group, $store, $reloadedSkuCache));
             $listPrice = $this->nostoCurrencyHelper->convertToTaggingPrice(
                 $this->nostoPriceHelper->getProductDisplayPrice(
                     $product,
@@ -148,15 +150,20 @@ class Builder
      * @param Product $product
      * @param Group $group
      * @param Store $store
+     * @param array $reloadedSkuCache
      * @return float
      * @throws LocalizedException
      * @throws NoSuchEntityException|NostoException
      */
-    private function getLowestVariationPrice(Product $product, Group $group, Store $store)
-    {
+    private function getLowestVariationPrice(
+        Product $product,
+        Group $group,
+        Store $store,
+        array &$reloadedSkuCache
+    ) {
         // If product is configurable, the parent has no customer group price. Get SKU with lowest price
         if ($product->getTypeInstance() instanceof ConfigurableType) {
-            $product = $this->getMinPriceSku($product, $group, $store);
+            $product = $this->getMinPriceSku($product, $group, $store, $reloadedSkuCache);
         }
 
         // Only returns the SKU price if it's lower than final price
@@ -202,14 +209,25 @@ class Builder
      * Reads final_price from catalog_product_index_price for the given customer group
      * to identify the cheapest SKU without loading all child product objects.
      *
+     * $reloadedSkuCache memoizes reloadProduct() results by "skuId:storeId" for the
+     * duration of a single Variation\Collection::build() call (one call per customer
+     * group in that loop), so the same winning SKU is only force-reloaded once even
+     * when multiple groups resolve to it. Callers that don't need this (e.g. direct
+     * unit tests) may omit it — it defaults to a fresh, throwaway array.
+     *
      * @param MageProduct $product
      * @param Group $group
      * @param Store $store
+     * @param array $reloadedSkuCache
      * @return MageProduct
      * @throws NoSuchEntityException
      */
-    public function getMinPriceSku(Product $product, Group $group, Store $store): MageProduct
-    {
+    public function getMinPriceSku(
+        Product $product,
+        Group $group,
+        Store $store,
+        array &$reloadedSkuCache = []
+    ): MageProduct {
         if (!$product->getTypeInstance() instanceof ConfigurableType) {
             return $product;
         }
@@ -225,7 +243,14 @@ class Builder
         if ($minPriceSkuId === null) {
             return $this->getMinPriceSkuFallback($product, $group, $store);
         }
-        return $this->nostoProductRepository->reloadProduct($minPriceSkuId, (int)$store->getId());
+        $cacheKey = $minPriceSkuId . ':' . (int)$store->getId();
+        if (!array_key_exists($cacheKey, $reloadedSkuCache)) {
+            $reloadedSkuCache[$cacheKey] = $this->nostoProductRepository->reloadProduct(
+                $minPriceSkuId,
+                (int)$store->getId()
+            );
+        }
+        return $reloadedSkuCache[$cacheKey];
     }
 
     /**

--- a/Model/Product/Variation/Collection.php
+++ b/Model/Product/Variation/Collection.php
@@ -84,6 +84,11 @@ class Collection
     {
         $collection = new VariationCollection();
         $groups = $this->customerGroupManager->getLoggedInGroups();
+        // Scoped to this single build() call only (never a class property): shared across
+        // the customer-group loop below so the same winning SKU isn't force-reloaded once
+        // per group, but discarded as soon as this method returns so it can never leak
+        // stale state into the next product processed by this shared/singleton service.
+        $reloadedSkuCache = [];
         foreach ($groups as $group) {
             // For some (broken?) Magento setups the default group / default
             // variation is also part of the customer groups
@@ -96,7 +101,8 @@ class Collection
                     $product,
                     $nostoProduct,
                     $store,
-                    $group
+                    $group,
+                    $reloadedSkuCache
                 )
             );
         }

--- a/Test/Unit/Model/Product/Variation/BuilderTest.php
+++ b/Test/Unit/Model/Product/Variation/BuilderTest.php
@@ -192,6 +192,108 @@ class BuilderTest extends TestCase
     }
 
     /**
+     * Two different customer groups resolve to the same cheapest SKU on the same store.
+     * reloadProduct() is a forced, cache-bypassing load (it exists precisely to avoid stale
+     * data across a long-running batch/cron process) — but within a SINGLE product's build,
+     * paying that cost twice for the identical SKU+store pair is pure waste. When both calls
+     * share the same $reloadedSkuCache array, reloadProduct() must only run once.
+     *
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuReusesCacheForSameSkuAndStoreAcrossGroups(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20]);
+
+        $this->skuResourceMock->method('getMinPriceSkuId')
+            ->willReturn(20);
+
+        $cheapestSku = $this->createMock(Product::class);
+        $this->nostoProductRepositoryMock->expects($this->once())
+            ->method('reloadProduct')
+            ->with(20, 1)
+            ->willReturn($cheapestSku);
+
+        $reloadedSkuCache = [];
+
+        $firstGroup = $this->createMock(Group::class);
+        $firstGroup->method('getId')->willReturn('2');
+        $secondGroup = $this->createMock(Group::class);
+        $secondGroup->method('getId')->willReturn('3');
+
+        $firstResult = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $firstGroup,
+            $this->storeMock,
+            $reloadedSkuCache
+        );
+        $secondResult = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $secondGroup,
+            $this->storeMock,
+            $reloadedSkuCache
+        );
+
+        $this->assertSame($cheapestSku, $firstResult);
+        $this->assertSame($cheapestSku, $secondResult);
+    }
+
+    /**
+     * Two customer groups resolve to DIFFERENT cheapest SKUs (e.g. group-specific pricing
+     * changes which child wins) on the same store. The cache must key by skuId, not just
+     * store, so each distinct SKU still gets its own reloadProduct() call and no group's
+     * result is silently overwritten by another group's.
+     *
+     * @covers Builder::getMinPriceSku()
+     */
+    public function testGetMinPriceSkuReloadsSeparatelyForDifferentSkusAcrossGroups(): void
+    {
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20]);
+
+        $this->skuResourceMock->method('getMinPriceSkuId')
+            ->willReturnOnConsecutiveCalls(10, 20);
+
+        $skuTen = $this->createMock(Product::class);
+        $skuTwenty = $this->createMock(Product::class);
+        $this->nostoProductRepositoryMock->expects($this->exactly(2))
+            ->method('reloadProduct')
+            ->willReturnMap([
+                [10, 1, $skuTen],
+                [20, 1, $skuTwenty],
+            ]);
+
+        $reloadedSkuCache = [];
+
+        $firstGroup = $this->createMock(Group::class);
+        $firstGroup->method('getId')->willReturn('2');
+        $secondGroup = $this->createMock(Group::class);
+        $secondGroup->method('getId')->willReturn('3');
+
+        $firstResult = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $firstGroup,
+            $this->storeMock,
+            $reloadedSkuCache
+        );
+        $secondResult = $this->builder->getMinPriceSku(
+            $this->productMock,
+            $secondGroup,
+            $this->storeMock,
+            $reloadedSkuCache
+        );
+
+        $this->assertSame($skuTen, $firstResult);
+        $this->assertSame($skuTwenty, $secondResult);
+    }
+
+    /**
      * Index returns null and no in-stock children exist — parent product is returned.
      *
      * @covers Builder::getMinPriceSku()

--- a/Test/Unit/Model/Product/Variation/CollectionTest.php
+++ b/Test/Unit/Model/Product/Variation/CollectionTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nosto\Tagging\Test\Unit\Model\Product\Variation;
+
+use Magento\Catalog\Model\Product;
+use Magento\CatalogRule\Model\ResourceModel\Rule as RuleResourceModel;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
+use Magento\Customer\Api\GroupRepositoryInterface as GroupRepository;
+use Magento\Customer\Model\Data\Group;
+use Magento\Customer\Model\GroupManagement;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\Website;
+use Nosto\Model\Product\Product as NostoProduct;
+use Nosto\Tagging\Helper\Currency as CurrencyHelper;
+use Nosto\Tagging\Helper\Price as NostoPriceHelper;
+use Nosto\Tagging\Logger\Logger as NostoLogger;
+use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
+use Nosto\Tagging\Model\Product\Variation\Builder;
+use Nosto\Tagging\Model\Product\Variation\Collection;
+use Nosto\Tagging\Model\ResourceModel\Sku as SkuResource;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class CollectionTest extends TestCase
+{
+    private Collection $collection;
+
+    /** @var MockObject */
+    private $nostoProductRepositoryMock;
+
+    /** @var MockObject */
+    private $skuResourceMock;
+
+    /** @var MockObject */
+    private $customerGroupManagerMock;
+
+    /** @var MockObject */
+    private $productMock;
+
+    /** @var MockObject */
+    private $storeMock;
+
+    /** @var MockObject */
+    private $nostoProductMock;
+
+    protected function setUp(): void
+    {
+        // Builder has a generated factory in its constructor that doesn't exist on disk.
+        // Bypass the constructor and inject only the properties Collection::build() exercises.
+        $builder = $this->getMockBuilder(Builder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $this->nostoProductRepositoryMock = $this->createMock(NostoProductRepository::class);
+        $this->skuResourceMock = $this->getMockBuilder(SkuResource::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $ruleResourceModelMock = $this->createMock(RuleResourceModel::class);
+        $ruleResourceModelMock->method('getRulePrice')->willReturn(false);
+
+        $localeDateMock = $this->createMock(TimezoneInterface::class);
+        $localeDateMock->method('scopeDate')->willReturn(new \DateTime());
+
+        $nostoPriceHelperMock = $this->createMock(NostoPriceHelper::class);
+        $nostoPriceHelperMock->method('getProductDisplayPrice')->willReturn(10.0);
+        $nostoPriceHelperMock->method('getProductPrice')->willReturn(10.0);
+
+        $nostoCurrencyHelperMock = $this->createMock(CurrencyHelper::class);
+        $nostoCurrencyHelperMock->method('convertToTaggingPrice')->willReturnArgument(0);
+
+        $eventManagerMock = $this->createMock(ManagerInterface::class);
+        $loggerMock = $this->createMock(NostoLogger::class);
+
+        $this->injectProperty($builder, 'nostoProductRepository', $this->nostoProductRepositoryMock);
+        $this->injectProperty($builder, 'skuResource', $this->skuResourceMock);
+        $this->injectProperty($builder, 'ruleResourceModel', $ruleResourceModelMock);
+        $this->injectProperty($builder, 'localeDate', $localeDateMock);
+        $this->injectProperty($builder, 'nostoPriceHelper', $nostoPriceHelperMock);
+        $this->injectProperty($builder, 'nostoCurrencyHelper', $nostoCurrencyHelperMock);
+        $this->injectProperty($builder, 'eventManager', $eventManagerMock);
+        $this->injectProperty($builder, 'logger', $loggerMock);
+
+        $this->customerGroupManagerMock = $this->createMock(GroupManagement::class);
+        $groupRepositoryMock = $this->createMock(GroupRepository::class);
+
+        $this->collection = new Collection(
+            $builder,
+            $this->customerGroupManagerMock,
+            $groupRepositoryMock,
+            $builder
+        );
+
+        $websiteMock = $this->createMock(Website::class);
+
+        $this->storeMock = $this->createMock(Store::class);
+        $this->storeMock->method('getWebsite')->willReturn($websiteMock);
+        $this->storeMock->method('getId')->willReturn('1');
+        $this->storeMock->method('getWebsiteId')->willReturn('1');
+
+        $this->productMock = $this->createMock(Product::class);
+        $this->productMock->method('getTypeInstance')
+            ->willReturn($this->createMock(ConfigurableType::class));
+
+        $this->nostoProductMock = $this->createMock(NostoProduct::class);
+        $this->nostoProductMock->method('getVariationId')->willReturn('__default__');
+        $this->nostoProductMock->method('getAvailability')->willReturn('InStock');
+        $this->nostoProductMock->method('getPriceCurrencyCode')->willReturn('EUR');
+    }
+
+    /**
+     * Two logged-in customer groups both resolve to the same cheapest SKU on the same
+     * store. Collection::build() must share one $reloadedSkuCache across the group loop
+     * so Repository::reloadProduct() (a forced, cache-bypassing load) only runs once,
+     * even though two Variation objects are still produced — one per group.
+     *
+     * @covers Collection::build()
+     */
+    public function testBuildDedupesReloadProductAcrossGroupsForSameSku(): void
+    {
+        $groupOne = $this->createMock(Group::class);
+        $groupOne->method('getId')->willReturn('2');
+        $groupOne->method('getCode')->willReturn('general');
+
+        $groupTwo = $this->createMock(Group::class);
+        $groupTwo->method('getId')->willReturn('3');
+        $groupTwo->method('getCode')->willReturn('wholesale');
+
+        $this->customerGroupManagerMock->method('getLoggedInGroups')
+            ->willReturn([$groupOne, $groupTwo]);
+
+        $this->nostoProductRepositoryMock->method('getSkuIds')
+            ->willReturn([10 => 10, 20 => 20]);
+        $this->skuResourceMock->method('getMinPriceSkuId')->willReturn(20);
+
+        $cheapestSku = $this->createMock(Product::class);
+        $cheapestSku->method('getTierPrices')->willReturn([]);
+
+        $this->nostoProductRepositoryMock->expects($this->once())
+            ->method('reloadProduct')
+            ->with(20, 1)
+            ->willReturn($cheapestSku);
+
+        $result = $this->collection->build($this->productMock, $this->nostoProductMock, $this->storeMock);
+
+        $this->assertCount(2, $result);
+    }
+
+    private function injectProperty(object $target, string $name, object $value): void
+    {
+        // PHPUnit mocks are dynamically generated subclasses (e.g. Mock_Builder_xxx).
+        // ReflectionProperty cannot resolve a *private* property through a subclass
+        // name - only through the exact class that declares it - so walk up the
+        // hierarchy to find the declaring class first.
+        $class = get_class($target);
+        while ($class !== false && !property_exists($class, $name)) {
+            $class = get_parent_class($class);
+        }
+        $property = new ReflectionProperty($class ?: get_class($target), $name);
+        $property->setAccessible(true);
+        $property->setValue($target, $value);
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Goal: Stop the same cheapest-SKU child product from being force-reloaded once per Magento customer group when building Nosto variations for a configurable product, which is the dominant remaining cost behind the configurable-PDP slowdown reported in NS-14032.

What changed

Model/Product/Variation/Builder.php
- `getMinPriceSku()` now accepts an `array &$reloadedSkuCache = []` parameter and memoizes the result of `nostoProductRepository->reloadProduct()` by a `"{skuId}:{storeId}"` cache key. On a repeat lookup for the same SKU+store, it returns the already-loaded product instead of calling `reloadProduct()` again.
- `getLowestVariationPrice()` (private) and `build()` (public) now thread that same cache array through to `getMinPriceSku()`. The parameter is optional (defaults to a fresh `[]`) on the two public-facing methods so existing callers/tests are unaffected.

Model/Product/Variation/Collection.php
- `build()` — the only caller of `Builder::build()`, which loops once per logged-in customer group — now creates a single local `$reloadedSkuCache = []` array before the loop and passes the same array into every `variationBuilder->build()` call in that loop. The array is a plain method-local variable, never a class property, so it can't leak state or grow unbounded across the thousands of products this same singleton service processes in batch/cron sync runs — it's garbage collected the moment `build()` returns.

Test/Unit/Model/Product/Variation/BuilderTest.php
- Added coverage for two customer groups resolving to the **same** cheapest SKU (asserts `reloadProduct()` is called exactly once) and two groups resolving to **different** cheapest SKUs (asserts each still gets its own reload, keyed correctly, no cross-group clobbering).

Test/Unit/Model/Product/Variation/CollectionTest.php (new)
- Integration-level test using a real (constructor-bypassed, dependency-injected) `Builder` instance to verify the cache is genuinely shared end-to-end across `Collection::build()`'s group loop — not just at the `Builder` unit level.

Performance impact
- Why this exists: `reloadProduct()` calls `productRepository->getById($id, false, $storeId, true)` with `forceReload=true`, which deliberately bypasses Magento's own repository object cache (needed to avoid stale data across long-running batch/cron product syncs). Without this change, if a store has N customer groups and the same SKU happens to be cheapest for all of them (the common case when there's no group-specific pricing), that SKU gets fully reloaded — re-triggering `addExtensionAttributes` and its downstream extension-attribute plugins — N separate times per single page render, with zero request-level memoization.
- With this change, that same scenario reloads the winning SKU once per product build, not once per customer group.

Builds on #949 (merged), which fixed the SKU-selection query itself (indexed `catalog_product_index_price` lookup instead of loading every child product). This PR fixes the redundant *reload* of the SKU that query selects.

Probably for a follow-up

The wider ticket also reports `addExtensionAttributes` and category/media-gallery loads as a large share of trace time independent of customer-group count. I looked into a suspected N+1 in `DefaultCategoryService::getCategories()`/`getCategoryParentIds()` (each seemingly calling `$product->getCategoryCollection()` separately) and confirmed it's **not** actually a bug — `Magento\Catalog\Model\Product::getCategoryCollection()` already caches per product instance, so no duplicate query happens there. I'm not including a fix for it since there's nothing to fix.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://nostosolutions.atlassian.net/browse/NS-14032

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Cosy Direct reported severe TTFB degradation (up to ~59s) on configurable product pages with 30+ variants. New Relic traces showed `Nosto\Tagging\Model\Service\Product\CachingProductService` → `Magento\Catalog\Model\ProductRepository::addExtensionAttributes` consuming ~49% of total render time. #949 already addressed the SKU-selection part of that cost (`getMinPriceSku`). This PR addresses the remaining redundant-reload part: the price-variation loop in `Variation\Collection::build()` re-reloads the same winning SKU once per customer group instead of once per product.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests only (no live store available for this ticket). Added/ran:
- `Test/Unit/Model/Product/Variation/BuilderTest.php` (9 tests: 7 pre-existing + 2 new)
- `Test/Unit/Model/Product/Variation/CollectionTest.php` (new, 1 test)
- Full module suite: `vendor/bin/phpunit -c phpunit.xml` — 36 tests, 52 assertions, all passing.

(Note for reviewers on Apple Silicon / PHP 8.3 default installs: this repo's `composer.lock` pins platform PHP to 7.4.33, and the vendored Magento framework classes fatal under PHP 8.3's stricter `ArrayAccess` return-type checks — run tests with a PHP 7.4 binary, e.g. `php@7.4` via Homebrew.)

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
