### PR TITLE
NS-14429 Discontinue products in Nosto when visibility changes to Not Visible Individually

### DIFF
--- a/Model/Product/VisibilityResolver.php
+++ b/Model/Product/VisibilityResolver.php
@@ -77,7 +77,11 @@ class VisibilityResolver
             return [];
         }
 
+        // withStore()/withIds() mutate the builder's single shared collection instance
+        // in place, so a prior call's filters (e.g. a different store's scope) would
+        // otherwise leak into this one. Always start from a clean slate.
         $collection = $this->productCollectionBuilder
+            ->reset()
             ->withStore($store)
             ->withIds($productIds)
             ->build();

--- a/Model/Product/VisibilityResolver.php
+++ b/Model/Product/VisibilityResolver.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright (c) 2026, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2026 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\Product;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Store\Model\Store;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
+
+/**
+ * Resolves a product's effective visibility at a specific store's scope.
+ *
+ * Visibility is a store-scoped attribute: a store with its own override keeps that
+ * value regardless of what the default (store 0) value is. Callers that only just
+ * changed the default value must re-check each affected store here rather than
+ * assume the change applies everywhere.
+ */
+class VisibilityResolver
+{
+    /** @var CollectionBuilder */
+    private CollectionBuilder $productCollectionBuilder;
+
+    /**
+     * @param CollectionBuilder $productCollectionBuilder
+     */
+    public function __construct(CollectionBuilder $productCollectionBuilder)
+    {
+        $this->productCollectionBuilder = $productCollectionBuilder;
+    }
+
+    /**
+     * Returns, out of the given ids, the ones that resolve to a visibility other
+     * than "Not Visible Individually" at the given store's scope (the store's own
+     * override if it has one, otherwise the default value)
+     *
+     * @param int[] $productIds
+     * @param Store $store
+     * @return int[]
+     */
+    public function getIndividuallyVisibleProductIds(array $productIds, Store $store): array
+    {
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $collection = $this->productCollectionBuilder
+            ->withStore($store)
+            ->withIds($productIds)
+            ->build();
+        $collection->addAttributeToSelect(ProductInterface::VISIBILITY);
+
+        $ids = [];
+        foreach ($collection->getItems() as $item) {
+            if ((int)$item->getVisibility() !== Visibility::VISIBILITY_NOT_VISIBLE) {
+                $ids[] = (int)$item->getId();
+            }
+        }
+        return $ids;
+    }
+}

--- a/Model/ResourceModel/Product/WebsiteLink.php
+++ b/Model/ResourceModel/Product/WebsiteLink.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright (c) 2026, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2026 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Model\ResourceModel\Product;
+
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Batched counterpart to Magento\Catalog\Model\ResourceModel\Product\Website\Link,
+ * which only accepts a single product id. Used to avoid one query per product when
+ * resolving website assignments for a large batch (e.g. a mass product update).
+ */
+class WebsiteLink
+{
+    private const TABLE = 'catalog_product_website';
+
+    /** @var ResourceConnection */
+    private ResourceConnection $resourceConnection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(ResourceConnection $resourceConnection)
+    {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Returns website ids assigned to each of the given products, in a single query
+     *
+     * @param int[] $productIds
+     * @return array<int, int[]> product id => website ids
+     */
+    public function getWebsiteIdsByProductIds(array $productIds): array
+    {
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $connection = $this->resourceConnection->getConnection();
+        $select = $connection->select()
+            ->from($this->resourceConnection->getTableName(self::TABLE), ['product_id', 'website_id'])
+            ->where('product_id IN (?)', $productIds);
+
+        $websiteIdsByProduct = [];
+        foreach ($connection->fetchAll($select) as $row) { // @codingStandardsIgnoreLine
+            $websiteIdsByProduct[(int)$row['product_id']][] = (int)$row['website_id'];
+        }
+        return $websiteIdsByProduct;
+    }
+}

--- a/Model/ResourceModel/Product/WebsiteLink.php
+++ b/Model/ResourceModel/Product/WebsiteLink.php
@@ -47,6 +47,12 @@ class WebsiteLink
 {
     private const TABLE = 'catalog_product_website';
 
+    /**
+     * A grid "select all" mass action can span tens of thousands of ids, and a single
+     * IN () list that long risks exceeding the server's max_allowed_packet
+     */
+    private const CHUNK_SIZE = 1000;
+
     /** @var ResourceConnection */
     private ResourceConnection $resourceConnection;
 
@@ -59,7 +65,8 @@ class WebsiteLink
     }
 
     /**
-     * Returns website ids assigned to each of the given products, in a single query
+     * Returns website ids assigned to each of the given products, in one query per
+     * chunk of ids rather than one query per product
      *
      * @param int[] $productIds
      * @return array<int, int[]> product id => website ids
@@ -71,13 +78,17 @@ class WebsiteLink
         }
 
         $connection = $this->resourceConnection->getConnection();
-        $select = $connection->select()
-            ->from($this->resourceConnection->getTableName(self::TABLE), ['product_id', 'website_id'])
-            ->where('product_id IN (?)', $productIds);
+        $tableName = $this->resourceConnection->getTableName(self::TABLE);
 
         $websiteIdsByProduct = [];
-        foreach ($connection->fetchAll($select) as $row) { // @codingStandardsIgnoreLine
-            $websiteIdsByProduct[(int)$row['product_id']][] = (int)$row['website_id'];
+        foreach (array_chunk($productIds, self::CHUNK_SIZE) as $idChunk) {
+            $select = $connection->select()
+                ->from($tableName, ['product_id', 'website_id'])
+                ->where('product_id IN (?)', $idChunk);
+
+            foreach ($connection->fetchAll($select) as $row) { // @codingStandardsIgnoreLine
+                $websiteIdsByProduct[(int)$row['product_id']][] = (int)$row['website_id'];
+            }
         }
         return $websiteIdsByProduct;
     }

--- a/Plugin/ProductUpdate.php
+++ b/Plugin/ProductUpdate.php
@@ -158,7 +158,7 @@ class ProductUpdate
             $storeId = (int)$product->getStoreId();
             $productResource->addCommitCallback(
                 function () use ($product, $storeId) {
-                    $this->queueDiscontinueForHiddenVisibility($product, $storeId);
+                    $this->enqueueProductDelete($product, $storeId);
                 }
             );
         }
@@ -175,10 +175,20 @@ class ProductUpdate
         if (!$product->getId()) {
             return false;
         }
-        $origVisibility = (int)$product->getOrigData(ProductInterface::VISIBILITY);
+
         $newVisibility = (int)$product->getData(ProductInterface::VISIBILITY);
-        return $origVisibility !== Visibility::VISIBILITY_NOT_VISIBLE
-            && $newVisibility === Visibility::VISIBILITY_NOT_VISIBLE;
+        if ($newVisibility !== Visibility::VISIBILITY_NOT_VISIBLE) {
+            return false;
+        }
+
+        // The product is hidden after this save, so the discontinue is warranted on
+        // its own. Comparing against the original value only avoids re-sending for a
+        // product that was already hidden, and orig data is absent on a partially
+        // loaded model - so treat an unknown original as "was visible" and let the
+        // (idempotent) discontinue through rather than dropping a real transition.
+        $origVisibility = $product->getOrigData(ProductInterface::VISIBILITY);
+        return $origVisibility === null
+            || (int)$origVisibility !== Visibility::VISIBILITY_NOT_VISIBLE;
     }
 
     /**
@@ -190,8 +200,11 @@ class ProductUpdate
      * @param int $storeId
      * @return void
      */
-    private function queueDiscontinueForHiddenVisibility(AbstractModel $product, int $storeId): void
+    private function enqueueProductDelete(AbstractModel $product, int $storeId): void
     {
+        // Store 0 is the admin scope holding the Default Value: it is not a storefront
+        // and has no Nosto account of its own, so there is nothing to send it to. An
+        // edit made there is instead resolved into the real store views below.
         if ($storeId !== Store::DEFAULT_STORE_ID) {
             try {
                 $store = $this->nostoHelperScope->getStore($storeId);

--- a/Plugin/ProductUpdate.php
+++ b/Plugin/ProductUpdate.php
@@ -44,10 +44,12 @@ use Magento\Catalog\Model\ResourceModel\Product as MagentoResourceProduct;
 use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\Store;
 use Nosto\Tagging\Exception\ParentProductDisabledException;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Model\Indexer\ProductIndexer;
 use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
+use Nosto\Tagging\Model\Product\VisibilityResolver;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
 use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
@@ -81,6 +83,9 @@ class ProductUpdate
     /** @var ProductStoreLink */
     private ProductStoreLink $productStoreLink;
 
+    /** @var VisibilityResolver */
+    private VisibilityResolver $visibilityResolver;
+
     /**
      * ProductUpdate constructor.
      * @param IndexerRegistry $indexerRegistry
@@ -91,6 +96,7 @@ class ProductUpdate
      * @param NostoHelperScope $nostoHelperScope
      * @param CollectionBuilder $productCollectionBuilder
      * @param ProductStoreLink $productStoreLink
+     * @param VisibilityResolver $visibilityResolver
      */
     public function __construct(
         IndexerRegistry                $indexerRegistry,
@@ -100,7 +106,8 @@ class ProductUpdate
         ProductUpdateService           $productUpdateService,
         NostoHelperScope               $nostoHelperScope,
         CollectionBuilder              $productCollectionBuilder,
-        ProductStoreLink             $productStoreLink
+        ProductStoreLink             $productStoreLink,
+        VisibilityResolver $visibilityResolver
     ) {
         $this->indexerRegistry = $indexerRegistry;
         $this->productIndexer = $productIndexer;
@@ -110,6 +117,7 @@ class ProductUpdate
         $this->nostoHelperScope = $nostoHelperScope;
         $this->productCollectionBuilder = $productCollectionBuilder;
         $this->productStoreLink = $productStoreLink;
+        $this->visibilityResolver = $visibilityResolver;
     }
 
     /**
@@ -147,9 +155,10 @@ class ProductUpdate
         // individually-visible sync path (see ProductUpdateService::isIndividuallyVisible),
         // so without an explicit discontinue signal it stays an orphan in Nosto. NS-14429.
         if ($this->hasBecomeNotIndividuallyVisible($product)) {
+            $storeId = (int)$product->getStoreId();
             $productResource->addCommitCallback(
-                function () use ($product) {
-                    $this->queueDiscontinueForHiddenVisibility($product);
+                function () use ($product, $storeId) {
+                    $this->queueDiscontinueForHiddenVisibility($product, $storeId);
                 }
             );
         }
@@ -173,14 +182,26 @@ class ProductUpdate
     }
 
     /**
-     * Queues a discontinue message for every store view the product is currently
-     * assigned to, since it is no longer individually visible on any of them
+     * Queues a discontinue message for the store(s) affected by this visibility
+     * change: just the edited store if it was store-scoped, or every assigned store
+     * that has no override of its own if the Default Value was edited
      *
      * @param AbstractModel $product
+     * @param int $storeId
      * @return void
      */
-    private function queueDiscontinueForHiddenVisibility(AbstractModel $product): void
+    private function queueDiscontinueForHiddenVisibility(AbstractModel $product, int $storeId): void
     {
+        if ($storeId !== Store::DEFAULT_STORE_ID) {
+            try {
+                $store = $this->nostoHelperScope->getStore($storeId);
+                $this->productUpdateService->addIdsToDeleteMessageQueue([$product->getId()], $store);
+            } catch (Exception $e) {
+                $this->logger->exception($e);
+            }
+            return;
+        }
+
         try {
             $websiteIds = array_map(
                 'intval',
@@ -191,11 +212,19 @@ class ProductUpdate
             return;
         }
 
+        // Default Value only changes the fallback used by stores with no override
+        // of their own, so each assigned store must be re-checked individually.
         foreach ($websiteIds as $websiteId) {
             try {
                 $stores = $this->nostoHelperScope->getWebsite($websiteId)->getStores();
                 foreach ($stores as $store) {
-                    $this->productUpdateService->addIdsToDeleteMessageQueue([$product->getId()], $store);
+                    $stillVisible = $this->visibilityResolver->getIndividuallyVisibleProductIds(
+                        [(int)$product->getId()],
+                        $store
+                    );
+                    if (empty($stillVisible)) {
+                        $this->productUpdateService->addIdsToDeleteMessageQueue([$product->getId()], $store);
+                    }
                 }
             } catch (Exception $e) {
                 $this->logger->exception($e);

--- a/Plugin/ProductUpdate.php
+++ b/Plugin/ProductUpdate.php
@@ -209,6 +209,12 @@ class ProductUpdate
             try {
                 $store = $this->nostoHelperScope->getStore($storeId);
                 $this->productUpdateService->addIdsToDeleteMessageQueue([$product->getId()], $store);
+                $this->logger->debug(sprintf(
+                    'Queued discontinue for product %s on store %s'
+                    . ' (visibility changed to Not Visible Individually)',
+                    $product->getId(),
+                    $store->getCode()
+                ));
             } catch (Exception $e) {
                 $this->logger->exception($e);
             }
@@ -242,6 +248,12 @@ class ProductUpdate
                     );
                     if (empty($stillVisible)) {
                         $this->productUpdateService->addIdsToDeleteMessageQueue([$product->getId()], $store);
+                        $this->logger->debug(sprintf(
+                            'Queued discontinue for product %s on store %s'
+                            . ' (Default Value visibility change, no store override)',
+                            $product->getId(),
+                            $store->getCode()
+                        ));
                     }
                 }
             } catch (Exception $e) {

--- a/Plugin/ProductUpdate.php
+++ b/Plugin/ProductUpdate.php
@@ -38,6 +38,8 @@ namespace Nosto\Tagging\Plugin;
 
 use Closure;
 use Exception;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product as MagentoResourceProduct;
 use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
 use Magento\Framework\Indexer\IndexerRegistry;
@@ -141,7 +143,64 @@ class ProductUpdate
             );
         }
 
+        // A product that becomes "Not Visible Individually" disappears from the
+        // individually-visible sync path (see ProductUpdateService::isIndividuallyVisible),
+        // so without an explicit discontinue signal it stays an orphan in Nosto. NS-14429.
+        if ($this->hasBecomeNotIndividuallyVisible($product)) {
+            $productResource->addCommitCallback(
+                function () use ($product) {
+                    $this->queueDiscontinueForHiddenVisibility($product);
+                }
+            );
+        }
+
         return $proceed($product);
+    }
+
+    /**
+     * @param AbstractModel $product
+     * @return bool
+     */
+    private function hasBecomeNotIndividuallyVisible(AbstractModel $product): bool
+    {
+        if (!$product->getId()) {
+            return false;
+        }
+        $origVisibility = (int)$product->getOrigData(ProductInterface::VISIBILITY);
+        $newVisibility = (int)$product->getData(ProductInterface::VISIBILITY);
+        return $origVisibility !== Visibility::VISIBILITY_NOT_VISIBLE
+            && $newVisibility === Visibility::VISIBILITY_NOT_VISIBLE;
+    }
+
+    /**
+     * Queues a discontinue message for every store view the product is currently
+     * assigned to, since it is no longer individually visible on any of them
+     *
+     * @param AbstractModel $product
+     * @return void
+     */
+    private function queueDiscontinueForHiddenVisibility(AbstractModel $product): void
+    {
+        try {
+            $websiteIds = array_map(
+                'intval',
+                $this->productStoreLink->getWebsiteIdsByProductId((int)$product->getId())
+            );
+        } catch (Exception $e) {
+            $this->logger->exception($e);
+            return;
+        }
+
+        foreach ($websiteIds as $websiteId) {
+            try {
+                $stores = $this->nostoHelperScope->getWebsite($websiteId)->getStores();
+                foreach ($stores as $store) {
+                    $this->productUpdateService->addIdsToDeleteMessageQueue([$product->getId()], $store);
+                }
+            } catch (Exception $e) {
+                $this->logger->exception($e);
+            }
+        }
     }
 
     /**

--- a/Plugin/ProductUpdate.php
+++ b/Plugin/ProductUpdate.php
@@ -214,6 +214,11 @@ class ProductUpdate
 
         // Default Value only changes the fallback used by stores with no override
         // of their own, so each assigned store must be re-checked individually.
+        // The check reads post-change visibility, so a store already hidden by its
+        // own override before this edit is discontinued again rather than skipped.
+        // Deliberate: a repeat discontinue is a no-op for a product Nosto has
+        // already dropped, and separating the two cases would cost a second
+        // per-store query on every product save.
         foreach ($websiteIds as $websiteId) {
             try {
                 $stores = $this->nostoHelperScope->getWebsite($websiteId)->getStores();

--- a/Plugin/ProductVisibilityUpdate.php
+++ b/Plugin/ProductVisibilityUpdate.php
@@ -167,6 +167,12 @@ class ProductVisibilityUpdate
             try {
                 $store = $this->nostoHelperScope->getStore($storeId);
                 $this->productUpdateService->addIdsToDeleteMessageQueue($productIds, $store);
+                $this->logger->debug(sprintf(
+                    'Queued discontinue for %d product(s) on store %s'
+                    . ' (mass visibility update)',
+                    count($productIds),
+                    $store->getCode()
+                ));
             } catch (Exception $e) {
                 $this->logger->exception($e);
             }
@@ -217,11 +223,18 @@ class ProductVisibilityUpdate
                     $storesById[$targetStoreId]
                 );
                 $toDiscontinue = array_values(array_diff($idsForStore, $stillVisible));
-                if (!empty($toDiscontinue)) {
+                $discontinueCount = count($toDiscontinue); // @codingStandardsIgnoreLine
+                if ($discontinueCount > 0) {
                     $this->productUpdateService->addIdsToDeleteMessageQueue(
                         $toDiscontinue,
                         $storesById[$targetStoreId]
                     );
+                    $this->logger->debug(sprintf(
+                        'Queued discontinue for %d product(s) on store %s'
+                        . ' (mass visibility update, Default Value, no store override)',
+                        $discontinueCount,
+                        $storesById[$targetStoreId]->getCode()
+                    ));
                 }
             } catch (Exception $e) {
                 $this->logger->exception($e);

--- a/Plugin/ProductVisibilityUpdate.php
+++ b/Plugin/ProductVisibilityUpdate.php
@@ -175,6 +175,12 @@ class ProductVisibilityUpdate
         // queried once per store rather than once per product, since a mass update
         // can span thousands of ids and looping per product would mean a query per
         // product per store.
+        //
+        // This looks at post-change visibility only, so a store that was already
+        // hidden by its own override before this edit is discontinued again rather
+        // than skipped. Deliberate: telling the two apart would need a second
+        // per-store pass before the update runs, and a repeat discontinue is a no-op
+        // for a product Nosto has already dropped.
         try {
             $websiteIdsByProduct = $this->productWebsiteLink->getWebsiteIdsByProductIds($productIds);
         } catch (Exception $e) {

--- a/Plugin/ProductVisibilityUpdate.php
+++ b/Plugin/ProductVisibilityUpdate.php
@@ -110,6 +110,10 @@ class ProductVisibilityUpdate
         $attrData,
         $storeId
     ) {
+        // Narrow the plugin to the only case it cares about before doing any work:
+        // a mass update that sets visibility to "Not Visible Individually". Every
+        // other attribute change - and every visibility change to a visible value -
+        // falls straight through to the original method with no added queries.
         $targetsHiddenVisibility = isset($attrData[ProductInterface::VISIBILITY])
             && (int)$attrData[ProductInterface::VISIBILITY] === Visibility::VISIBILITY_NOT_VISIBLE;
 

--- a/Plugin/ProductVisibilityUpdate.php
+++ b/Plugin/ProductVisibilityUpdate.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Copyright (c) 2026, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2026 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Tagging\Plugin;
+
+use Closure;
+use Exception;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Action as ProductAction;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
+use Magento\Store\Model\Store;
+use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+use Nosto\Tagging\Logger\Logger as NostoLogger;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
+use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
+
+/**
+ * Plugin for the product grid's mass "Update Attributes" action.
+ *
+ * Action::updateAttributes() writes EAV values directly via its own resource model
+ * and never touches ResourceModel\Product::save(), so Plugin\ProductUpdate::aroundSave
+ * never runs for it. Without this plugin, bulk-hiding many products at once (the
+ * most common way to trigger NS-14429) would leave them as orphans in Nosto forever.
+ */
+class ProductVisibilityUpdate
+{
+    /** @var CollectionBuilder */
+    private CollectionBuilder $productCollectionBuilder;
+
+    /** @var ProductStoreLink */
+    private ProductStoreLink $productStoreLink;
+
+    /** @var NostoHelperScope */
+    private NostoHelperScope $nostoHelperScope;
+
+    /** @var ProductUpdateService */
+    private ProductUpdateService $productUpdateService;
+
+    /** @var NostoLogger */
+    private NostoLogger $logger;
+
+    /**
+     * @param CollectionBuilder $productCollectionBuilder
+     * @param ProductStoreLink $productStoreLink
+     * @param NostoHelperScope $nostoHelperScope
+     * @param ProductUpdateService $productUpdateService
+     * @param NostoLogger $logger
+     */
+    public function __construct(
+        CollectionBuilder $productCollectionBuilder,
+        ProductStoreLink $productStoreLink,
+        NostoHelperScope $nostoHelperScope,
+        ProductUpdateService $productUpdateService,
+        NostoLogger $logger
+    ) {
+        $this->productCollectionBuilder = $productCollectionBuilder;
+        $this->productStoreLink = $productStoreLink;
+        $this->nostoHelperScope = $nostoHelperScope;
+        $this->productUpdateService = $productUpdateService;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param ProductAction $subject
+     * @param Closure $proceed
+     * @param array $productIds
+     * @param array $attrData
+     * @param int|string $storeId
+     * @return mixed
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function aroundUpdateAttributes(
+        ProductAction $subject,
+        Closure $proceed,
+        $productIds,
+        $attrData,
+        $storeId
+    ) {
+        $targetsHiddenVisibility = isset($attrData[ProductInterface::VISIBILITY])
+            && (int)$attrData[ProductInterface::VISIBILITY] === Visibility::VISIBILITY_NOT_VISIBLE;
+
+        if (!$targetsHiddenVisibility || empty($productIds)) {
+            return $proceed($productIds, $attrData, $storeId);
+        }
+
+        $idsToDiscontinue = $this->getCurrentlyVisibleProductIds($productIds, (int)$storeId);
+
+        $result = $proceed($productIds, $attrData, $storeId);
+
+        $this->queueDiscontinue($idsToDiscontinue, (int)$storeId);
+
+        return $result;
+    }
+
+    /**
+     * Reads, before the mass update runs, which of the given products are still
+     * individually visible at the scope of this change
+     *
+     * @param int[] $productIds
+     * @param int $storeId
+     * @return int[]
+     */
+    private function getCurrentlyVisibleProductIds(array $productIds, int $storeId): array
+    {
+        try {
+            $store = $this->nostoHelperScope->getStore($storeId);
+            $collection = $this->productCollectionBuilder
+                ->withStore($store)
+                ->withIds($productIds)
+                ->build();
+            $collection->addAttributeToSelect(ProductInterface::VISIBILITY);
+
+            $ids = [];
+            foreach ($collection->getItems() as $item) {
+                if ((int)$item->getVisibility() !== Visibility::VISIBILITY_NOT_VISIBLE) {
+                    $ids[] = (int)$item->getId();
+                }
+            }
+            return $ids;
+        } catch (Exception $e) {
+            $this->logger->exception($e);
+            return [];
+        }
+    }
+
+    /**
+     * Queues a discontinue message for products that were individually visible
+     * before this mass update and have just become hidden
+     *
+     * @param int[] $productIds
+     * @param int $storeId
+     * @return void
+     */
+    private function queueDiscontinue(array $productIds, int $storeId): void
+    {
+        if (empty($productIds)) {
+            return;
+        }
+
+        if ($storeId !== Store::DEFAULT_STORE_ID) {
+            try {
+                $store = $this->nostoHelperScope->getStore($storeId);
+                $this->productUpdateService->addIdsToDeleteMessageQueue($productIds, $store);
+            } catch (Exception $e) {
+                $this->logger->exception($e);
+            }
+            return;
+        }
+
+        // Default/All Store Views changes the fallback value for every store that
+        // has no override of its own, so each product must be discontinued on
+        // every store it is currently assigned to.
+        foreach ($productIds as $productId) {
+            try {
+                $websiteIds = array_map(
+                    'intval',
+                    $this->productStoreLink->getWebsiteIdsByProductId($productId)
+                );
+            } catch (Exception $e) {
+                $this->logger->exception($e);
+                continue;
+            }
+            foreach ($websiteIds as $websiteId) {
+                try {
+                    $stores = $this->nostoHelperScope->getWebsite($websiteId)->getStores();
+                    foreach ($stores as $store) {
+                        $this->productUpdateService->addIdsToDeleteMessageQueue([$productId], $store);
+                    }
+                } catch (Exception $e) {
+                    $this->logger->exception($e);
+                }
+            }
+        }
+    }
+}

--- a/Plugin/ProductVisibilityUpdate.php
+++ b/Plugin/ProductVisibilityUpdate.php
@@ -41,11 +41,11 @@ use Exception;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product\Action as ProductAction;
 use Magento\Catalog\Model\Product\Visibility;
-use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
 use Magento\Store\Model\Store;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Product\VisibilityResolver;
+use Nosto\Tagging\Model\ResourceModel\Product\WebsiteLink;
 use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
 
 /**
@@ -61,8 +61,8 @@ class ProductVisibilityUpdate
     /** @var VisibilityResolver */
     private VisibilityResolver $visibilityResolver;
 
-    /** @var ProductStoreLink */
-    private ProductStoreLink $productStoreLink;
+    /** @var WebsiteLink */
+    private WebsiteLink $productWebsiteLink;
 
     /** @var NostoHelperScope */
     private NostoHelperScope $nostoHelperScope;
@@ -75,20 +75,20 @@ class ProductVisibilityUpdate
 
     /**
      * @param VisibilityResolver $visibilityResolver
-     * @param ProductStoreLink $productStoreLink
+     * @param WebsiteLink $productWebsiteLink
      * @param NostoHelperScope $nostoHelperScope
      * @param ProductUpdateService $productUpdateService
      * @param NostoLogger $logger
      */
     public function __construct(
         VisibilityResolver $visibilityResolver,
-        ProductStoreLink $productStoreLink,
+        WebsiteLink $productWebsiteLink,
         NostoHelperScope $nostoHelperScope,
         ProductUpdateService $productUpdateService,
         NostoLogger $logger
     ) {
         $this->visibilityResolver = $visibilityResolver;
-        $this->productStoreLink = $productStoreLink;
+        $this->productWebsiteLink = $productWebsiteLink;
         $this->nostoHelperScope = $nostoHelperScope;
         $this->productUpdateService = $productUpdateService;
         $this->logger = $logger;
@@ -170,29 +170,51 @@ class ProductVisibilityUpdate
         }
 
         // Default/All Store Views only changes the fallback value for stores that
-        // have no override of their own, so each assigned store must be re-checked
-        // individually: a store with its own override keeps its value regardless.
-        foreach ($productIds as $productId) {
-            try {
-                $websiteIds = array_map(
-                    'intval',
-                    $this->productStoreLink->getWebsiteIdsByProductId($productId)
-                );
-            } catch (Exception $e) {
-                $this->logger->exception($e);
-                continue;
-            }
+        // have no override of their own, so each assigned store must be re-checked:
+        // a store with its own override keeps its value regardless. Grouped and
+        // queried once per store rather than once per product, since a mass update
+        // can span thousands of ids and looping per product would mean a query per
+        // product per store.
+        try {
+            $websiteIdsByProduct = $this->productWebsiteLink->getWebsiteIdsByProductIds($productIds);
+        } catch (Exception $e) {
+            $this->logger->exception($e);
+            return;
+        }
+
+        $storesById = [];
+        $productIdsByStoreId = [];
+        foreach ($websiteIdsByProduct as $productId => $websiteIds) {
             foreach ($websiteIds as $websiteId) {
                 try {
                     $stores = $this->nostoHelperScope->getWebsite($websiteId)->getStores();
-                    foreach ($stores as $store) {
-                        if (empty($this->visibilityResolver->getIndividuallyVisibleProductIds([$productId], $store))) {
-                            $this->productUpdateService->addIdsToDeleteMessageQueue([$productId], $store);
-                        }
-                    }
                 } catch (Exception $e) {
                     $this->logger->exception($e);
+                    continue;
                 }
+                foreach ($stores as $store) {
+                    $storesById[$store->getId()] = $store;
+                    $productIdsByStoreId[$store->getId()][$productId] = $productId;
+                }
+            }
+        }
+
+        foreach ($productIdsByStoreId as $targetStoreId => $idsForStore) {
+            $idsForStore = array_values($idsForStore);
+            try {
+                $stillVisible = $this->visibilityResolver->getIndividuallyVisibleProductIds(
+                    $idsForStore,
+                    $storesById[$targetStoreId]
+                );
+                $toDiscontinue = array_values(array_diff($idsForStore, $stillVisible));
+                if (!empty($toDiscontinue)) {
+                    $this->productUpdateService->addIdsToDeleteMessageQueue(
+                        $toDiscontinue,
+                        $storesById[$targetStoreId]
+                    );
+                }
+            } catch (Exception $e) {
+                $this->logger->exception($e);
             }
         }
     }

--- a/Plugin/ProductVisibilityUpdate.php
+++ b/Plugin/ProductVisibilityUpdate.php
@@ -45,7 +45,7 @@ use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink
 use Magento\Store\Model\Store;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
-use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
+use Nosto\Tagging\Model\Product\VisibilityResolver;
 use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
 
 /**
@@ -58,8 +58,8 @@ use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
  */
 class ProductVisibilityUpdate
 {
-    /** @var CollectionBuilder */
-    private CollectionBuilder $productCollectionBuilder;
+    /** @var VisibilityResolver */
+    private VisibilityResolver $visibilityResolver;
 
     /** @var ProductStoreLink */
     private ProductStoreLink $productStoreLink;
@@ -74,20 +74,20 @@ class ProductVisibilityUpdate
     private NostoLogger $logger;
 
     /**
-     * @param CollectionBuilder $productCollectionBuilder
+     * @param VisibilityResolver $visibilityResolver
      * @param ProductStoreLink $productStoreLink
      * @param NostoHelperScope $nostoHelperScope
      * @param ProductUpdateService $productUpdateService
      * @param NostoLogger $logger
      */
     public function __construct(
-        CollectionBuilder $productCollectionBuilder,
+        VisibilityResolver $visibilityResolver,
         ProductStoreLink $productStoreLink,
         NostoHelperScope $nostoHelperScope,
         ProductUpdateService $productUpdateService,
         NostoLogger $logger
     ) {
-        $this->productCollectionBuilder = $productCollectionBuilder;
+        $this->visibilityResolver = $visibilityResolver;
         $this->productStoreLink = $productStoreLink;
         $this->nostoHelperScope = $nostoHelperScope;
         $this->productUpdateService = $productUpdateService;
@@ -138,19 +138,7 @@ class ProductVisibilityUpdate
     {
         try {
             $store = $this->nostoHelperScope->getStore($storeId);
-            $collection = $this->productCollectionBuilder
-                ->withStore($store)
-                ->withIds($productIds)
-                ->build();
-            $collection->addAttributeToSelect(ProductInterface::VISIBILITY);
-
-            $ids = [];
-            foreach ($collection->getItems() as $item) {
-                if ((int)$item->getVisibility() !== Visibility::VISIBILITY_NOT_VISIBLE) {
-                    $ids[] = (int)$item->getId();
-                }
-            }
-            return $ids;
+            return $this->visibilityResolver->getIndividuallyVisibleProductIds($productIds, $store);
         } catch (Exception $e) {
             $this->logger->exception($e);
             return [];
@@ -181,9 +169,9 @@ class ProductVisibilityUpdate
             return;
         }
 
-        // Default/All Store Views changes the fallback value for every store that
-        // has no override of its own, so each product must be discontinued on
-        // every store it is currently assigned to.
+        // Default/All Store Views only changes the fallback value for stores that
+        // have no override of their own, so each assigned store must be re-checked
+        // individually: a store with its own override keeps its value regardless.
         foreach ($productIds as $productId) {
             try {
                 $websiteIds = array_map(
@@ -198,7 +186,9 @@ class ProductVisibilityUpdate
                 try {
                     $stores = $this->nostoHelperScope->getWebsite($websiteId)->getStores();
                     foreach ($stores as $store) {
-                        $this->productUpdateService->addIdsToDeleteMessageQueue([$productId], $store);
+                        if (empty($this->visibilityResolver->getIndividuallyVisibleProductIds([$productId], $store))) {
+                            $this->productUpdateService->addIdsToDeleteMessageQueue([$productId], $store);
+                        }
                     }
                 } catch (Exception $e) {
                     $this->logger->exception($e);

--- a/Test/Unit/Model/Product/VisibilityResolverTest.php
+++ b/Test/Unit/Model/Product/VisibilityResolverTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Copyright (c) 2026, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2026 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nosto\Tagging\Test\Unit\Model\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Store\Model\Store;
+use Nosto\Tagging\Model\Product\VisibilityResolver;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class VisibilityResolverTest extends TestCase
+{
+    /** @var VisibilityResolver */
+    private VisibilityResolver $resolver;
+
+    /** @var CollectionBuilder|MockObject */
+    private MockObject $collectionBuilderMock;
+
+    /** @var ProductCollection|MockObject */
+    private MockObject $collectionMock;
+
+    protected function setUp(): void
+    {
+        $this->collectionMock = $this->createMock(ProductCollection::class);
+
+        $this->collectionBuilderMock = $this->createMock(CollectionBuilder::class);
+        $this->collectionBuilderMock->method('withStore')->willReturnSelf();
+        $this->collectionBuilderMock->method('withIds')->willReturnSelf();
+        $this->collectionBuilderMock->method('build')->willReturn($this->collectionMock);
+
+        $this->resolver = new VisibilityResolver($this->collectionBuilderMock);
+    }
+
+    /**
+     * @param int $id
+     * @param int $visibility
+     * @return Product|MockObject
+     */
+    private function mockProductItem(int $id, int $visibility): MockObject
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getId')->willReturn($id);
+        $product->method('getVisibility')->willReturn($visibility);
+        return $product;
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Model\Product\VisibilityResolver::getIndividuallyVisibleProductIds()
+     */
+    public function testReturnsOnlyIdsThatAreIndividuallyVisibleAtTheGivenStore(): void
+    {
+        $this->collectionMock->method('getItems')->willReturn([
+            $this->mockProductItem(11, Visibility::VISIBILITY_BOTH),
+            $this->mockProductItem(22, Visibility::VISIBILITY_NOT_VISIBLE),
+            $this->mockProductItem(33, Visibility::VISIBILITY_IN_SEARCH),
+        ]);
+
+        $store = $this->createMock(Store::class);
+        $this->collectionBuilderMock->expects($this->once())->method('withStore')->with($store)->willReturnSelf();
+        $this->collectionBuilderMock->expects($this->once())->method('withIds')->with([11, 22, 33])->willReturnSelf();
+
+        $result = $this->resolver->getIndividuallyVisibleProductIds([11, 22, 33], $store);
+
+        $this->assertSame([11, 33], $result);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Model\Product\VisibilityResolver::getIndividuallyVisibleProductIds()
+     */
+    public function testEmptyProductIdsReturnsEmptyWithoutBuildingCollection(): void
+    {
+        $this->collectionBuilderMock->expects($this->never())->method('withIds');
+
+        $result = $this->resolver->getIndividuallyVisibleProductIds([], $this->createMock(Store::class));
+
+        $this->assertSame([], $result);
+    }
+}

--- a/Test/Unit/Model/Product/VisibilityResolverTest.php
+++ b/Test/Unit/Model/Product/VisibilityResolverTest.php
@@ -64,6 +64,7 @@ class VisibilityResolverTest extends TestCase
         $this->collectionMock = $this->createMock(ProductCollection::class);
 
         $this->collectionBuilderMock = $this->createMock(CollectionBuilder::class);
+        $this->collectionBuilderMock->method('reset')->willReturnSelf();
         $this->collectionBuilderMock->method('withStore')->willReturnSelf();
         $this->collectionBuilderMock->method('withIds')->willReturnSelf();
         $this->collectionBuilderMock->method('build')->willReturn($this->collectionMock);
@@ -114,5 +115,18 @@ class VisibilityResolverTest extends TestCase
         $result = $this->resolver->getIndividuallyVisibleProductIds([], $this->createMock(Store::class));
 
         $this->assertSame([], $result);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Model\Product\VisibilityResolver::getIndividuallyVisibleProductIds()
+     */
+    public function testResetsTheBuilderBeforeEveryQuerySoSequentialStoresDoNotMix(): void
+    {
+        $this->collectionMock->method('getItems')->willReturn([]);
+
+        $this->collectionBuilderMock->expects($this->exactly(2))->method('reset')->willReturnSelf();
+
+        $this->resolver->getIndividuallyVisibleProductIds([11], $this->createMock(Store::class));
+        $this->resolver->getIndividuallyVisibleProductIds([22], $this->createMock(Store::class));
     }
 }

--- a/Test/Unit/Model/ResourceModel/Product/WebsiteLinkTest.php
+++ b/Test/Unit/Model/ResourceModel/Product/WebsiteLinkTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Copyright (c) 2026, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2026 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nosto\Tagging\Test\Unit\Model\ResourceModel\Product;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Nosto\Tagging\Model\ResourceModel\Product\WebsiteLink;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class WebsiteLinkTest extends TestCase
+{
+    /** @var WebsiteLink */
+    private WebsiteLink $websiteLink;
+
+    /** @var AdapterInterface|MockObject */
+    private MockObject $connectionMock;
+
+    protected function setUp(): void
+    {
+        $selectMock = $this->createMock(Select::class);
+        $selectMock->method('from')->willReturnSelf();
+        $selectMock->method('where')->willReturnSelf();
+
+        $this->connectionMock = $this->createMock(AdapterInterface::class);
+        $this->connectionMock->method('select')->willReturn($selectMock);
+
+        $resourceConnectionMock = $this->createMock(ResourceConnection::class);
+        $resourceConnectionMock->method('getConnection')->willReturn($this->connectionMock);
+        $resourceConnectionMock->method('getTableName')->willReturn('catalog_product_website');
+
+        $this->websiteLink = new WebsiteLink($resourceConnectionMock);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Model\ResourceModel\Product\WebsiteLink::getWebsiteIdsByProductIds()
+     */
+    public function testGroupsWebsiteIdsByProductIdInOneQuery(): void
+    {
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn([
+                ['product_id' => '11', 'website_id' => '1'],
+                ['product_id' => '11', 'website_id' => '2'],
+                ['product_id' => '22', 'website_id' => '1'],
+            ]);
+
+        $result = $this->websiteLink->getWebsiteIdsByProductIds([11, 22]);
+
+        $this->assertSame([11 => [1, 2], 22 => [1]], $result);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Model\ResourceModel\Product\WebsiteLink::getWebsiteIdsByProductIds()
+     */
+    public function testEmptyProductIdsReturnsEmptyArrayWithoutQuerying(): void
+    {
+        $this->connectionMock->expects($this->never())->method('fetchAll');
+
+        $result = $this->websiteLink->getWebsiteIdsByProductIds([]);
+
+        $this->assertSame([], $result);
+    }
+}

--- a/Test/Unit/Model/ResourceModel/Product/WebsiteLinkTest.php
+++ b/Test/Unit/Model/ResourceModel/Product/WebsiteLinkTest.php
@@ -91,6 +91,26 @@ class WebsiteLinkTest extends TestCase
     /**
      * @covers \Nosto\Tagging\Model\ResourceModel\Product\WebsiteLink::getWebsiteIdsByProductIds()
      */
+    public function testSplitsLargeIdSetsIntoChunkedQueriesAndMergesTheResults(): void
+    {
+        $productIds = range(1, 2500);
+
+        $this->connectionMock->expects($this->exactly(3))
+            ->method('fetchAll')
+            ->willReturnOnConsecutiveCalls(
+                [['product_id' => '1', 'website_id' => '1']],
+                [['product_id' => '1001', 'website_id' => '2']],
+                [['product_id' => '2001', 'website_id' => '3']]
+            );
+
+        $result = $this->websiteLink->getWebsiteIdsByProductIds($productIds);
+
+        $this->assertSame([1 => [1], 1001 => [2], 2001 => [3]], $result);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Model\ResourceModel\Product\WebsiteLink::getWebsiteIdsByProductIds()
+     */
     public function testEmptyProductIdsReturnsEmptyArrayWithoutQuerying(): void
     {
         $this->connectionMock->expects($this->never())->method('fetchAll');

--- a/Test/Unit/Plugin/ProductUpdateTest.php
+++ b/Test/Unit/Plugin/ProductUpdateTest.php
@@ -52,6 +52,7 @@ use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Indexer\ProductIndexer;
 use Nosto\Tagging\Model\Product\Repository as NostoProductRepository;
+use Nosto\Tagging\Model\Product\VisibilityResolver;
 use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
 use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
 use Nosto\Tagging\Plugin\ProductUpdate;
@@ -83,6 +84,9 @@ class ProductUpdateTest extends TestCase
     /** @var ProductStoreLink|MockObject */
     private MockObject $productStoreLinkMock;
 
+    /** @var VisibilityResolver|MockObject */
+    private MockObject $visibilityResolverMock;
+
     /** @var callable[] */
     private array $commitCallbacks = [];
 
@@ -107,6 +111,7 @@ class ProductUpdateTest extends TestCase
         $this->productUpdateServiceMock = $this->createMock(ProductUpdateService::class);
         $this->nostoHelperScopeMock = $this->createMock(NostoHelperScope::class);
         $this->productStoreLinkMock = $this->createMock(ProductStoreLink::class);
+        $this->visibilityResolverMock = $this->createMock(VisibilityResolver::class);
 
         $this->plugin = new ProductUpdate(
             $indexerRegistryMock,
@@ -116,7 +121,8 @@ class ProductUpdateTest extends TestCase
             $this->productUpdateServiceMock,
             $this->nostoHelperScopeMock,
             $this->createMock(CollectionBuilder::class),
-            $this->productStoreLinkMock
+            $this->productStoreLinkMock,
+            $this->visibilityResolverMock
         );
     }
 
@@ -291,6 +297,7 @@ class ProductUpdateTest extends TestCase
         $this->productMock->method('getData')
             ->with(ProductInterface::VISIBILITY)
             ->willReturn(Visibility::VISIBILITY_NOT_VISIBLE);
+        $this->productMock->method('getStoreId')->willReturn(0);
 
         $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->willReturn(['2']);
 
@@ -298,6 +305,11 @@ class ProductUpdateTest extends TestCase
         $this->nostoHelperScopeMock->method('getWebsite')
             ->with(2)
             ->willReturn($this->mockStore([$store]));
+
+        // No store-level override, so the store inherits the new hidden default.
+        $this->visibilityResolverMock->method('getIndividuallyVisibleProductIds')
+            ->with([self::PRODUCT_ID], $store)
+            ->willReturn([]);
 
         $this->productUpdateServiceMock->expects($this->once())
             ->method('addIdsToDeleteMessageQueue')
@@ -312,6 +324,87 @@ class ProductUpdateTest extends TestCase
         );
 
         $this->assertSame('saved', $result);
+        $this->runCommitCallbacks();
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductUpdate::aroundSave()
+     */
+    public function testAroundSaveQueuesDiscontinueOnlyForTheEditedStoreWhenStoreScoped(): void
+    {
+        $this->indexerMock->method('isScheduled')->willReturn(true);
+
+        $this->productMock->method('getOrigData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_BOTH);
+        $this->productMock->method('getData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_NOT_VISIBLE);
+        $this->productMock->method('getStoreId')->willReturn(5);
+
+        $store = $this->createMock(Store::class);
+        $this->nostoHelperScopeMock->method('getStore')->with(5)->willReturn($store);
+
+        // getWebsiteIdsByProductId still fires for the unrelated store-removal check
+        // (see getPersistedStoreIds); the store-scoped visibility change must not add
+        // any further calls to it, since that store is already known.
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->willReturn(['1']);
+        $this->visibilityResolverMock->expects($this->never())->method('getIndividuallyVisibleProductIds');
+
+        $this->productUpdateServiceMock->expects($this->once())
+            ->method('addIdsToDeleteMessageQueue')
+            ->with([self::PRODUCT_ID], $store);
+
+        $this->plugin->aroundSave(
+            $this->productResourceMock,
+            function () {
+                return 'saved';
+            },
+            $this->productMock
+        );
+        $this->runCommitCallbacks();
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductUpdate::aroundSave()
+     */
+    public function testAroundSaveSkipsStoresWithTheirOwnVisibilityOverrideAtDefaultScope(): void
+    {
+        $this->indexerMock->method('isScheduled')->willReturn(true);
+
+        $this->productMock->method('getOrigData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_BOTH);
+        $this->productMock->method('getData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_NOT_VISIBLE);
+        $this->productMock->method('getStoreId')->willReturn(0);
+
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->willReturn(['2']);
+
+        $storeA = $this->createMock(Store::class);
+        $storeB = $this->createMock(Store::class);
+        $this->nostoHelperScopeMock->method('getWebsite')
+            ->with(2)
+            ->willReturn($this->mockStore([$storeA, $storeB]));
+
+        // Store B has its own visibility override that keeps it visible.
+        $this->visibilityResolverMock->method('getIndividuallyVisibleProductIds')
+            ->willReturnCallback(function (array $ids, Store $store) use ($storeB) {
+                return $store === $storeB ? [self::PRODUCT_ID] : [];
+            });
+
+        $this->productUpdateServiceMock->expects($this->once())
+            ->method('addIdsToDeleteMessageQueue')
+            ->with([self::PRODUCT_ID], $storeA);
+
+        $this->plugin->aroundSave(
+            $this->productResourceMock,
+            function () {
+                return 'saved';
+            },
+            $this->productMock
+        );
         $this->runCommitCallbacks();
     }
 

--- a/Test/Unit/Plugin/ProductUpdateTest.php
+++ b/Test/Unit/Plugin/ProductUpdateTest.php
@@ -328,6 +328,46 @@ class ProductUpdateTest extends TestCase
     }
 
     /**
+     * A partially loaded product carries no original visibility value. The product is
+     * hidden after the save either way, so the discontinue must still be sent rather
+     * than dropped because the previous value is unknown.
+     *
+     * @covers \Nosto\Tagging\Plugin\ProductUpdate::aroundSave()
+     */
+    public function testAroundSaveQueuesDiscontinueWhenTheOriginalVisibilityIsUnknown(): void
+    {
+        $this->indexerMock->method('isScheduled')->willReturn(true);
+
+        $this->productMock->method('getOrigData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(null);
+        $this->productMock->method('getData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_NOT_VISIBLE);
+        $this->productMock->method('getStoreId')->willReturn(3);
+
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->willReturn(['2']);
+
+        $store = $this->createMock(Store::class);
+        $this->nostoHelperScopeMock->method('getStore')->with(3)->willReturn($store);
+
+        $this->productUpdateServiceMock->expects($this->once())
+            ->method('addIdsToDeleteMessageQueue')
+            ->with([self::PRODUCT_ID], $store);
+
+        $result = $this->plugin->aroundSave(
+            $this->productResourceMock,
+            function () {
+                return 'saved';
+            },
+            $this->productMock
+        );
+
+        $this->assertSame('saved', $result);
+        $this->runCommitCallbacks();
+    }
+
+    /**
      * @covers \Nosto\Tagging\Plugin\ProductUpdate::aroundSave()
      */
     public function testAroundSaveQueuesDiscontinueOnlyForTheEditedStoreWhenStoreScoped(): void

--- a/Test/Unit/Plugin/ProductUpdateTest.php
+++ b/Test/Unit/Plugin/ProductUpdateTest.php
@@ -87,6 +87,9 @@ class ProductUpdateTest extends TestCase
     /** @var VisibilityResolver|MockObject */
     private MockObject $visibilityResolverMock;
 
+    /** @var NostoLogger|MockObject */
+    private MockObject $loggerMock;
+
     /** @var callable[] */
     private array $commitCallbacks = [];
 
@@ -112,12 +115,13 @@ class ProductUpdateTest extends TestCase
         $this->nostoHelperScopeMock = $this->createMock(NostoHelperScope::class);
         $this->productStoreLinkMock = $this->createMock(ProductStoreLink::class);
         $this->visibilityResolverMock = $this->createMock(VisibilityResolver::class);
+        $this->loggerMock = $this->createMock(NostoLogger::class);
 
         $this->plugin = new ProductUpdate(
             $indexerRegistryMock,
             $this->createMock(ProductIndexer::class),
             $this->createMock(NostoProductRepository::class),
-            $this->createMock(NostoLogger::class),
+            $this->loggerMock,
             $this->productUpdateServiceMock,
             $this->nostoHelperScopeMock,
             $this->createMock(CollectionBuilder::class),
@@ -394,6 +398,7 @@ class ProductUpdateTest extends TestCase
         $this->productUpdateServiceMock->expects($this->once())
             ->method('addIdsToDeleteMessageQueue')
             ->with([self::PRODUCT_ID], $store);
+        $this->loggerMock->expects($this->once())->method('debug');
 
         $this->plugin->aroundSave(
             $this->productResourceMock,
@@ -437,6 +442,7 @@ class ProductUpdateTest extends TestCase
         $this->productUpdateServiceMock->expects($this->once())
             ->method('addIdsToDeleteMessageQueue')
             ->with([self::PRODUCT_ID], $storeA);
+        $this->loggerMock->expects($this->once())->method('debug');
 
         $this->plugin->aroundSave(
             $this->productResourceMock,

--- a/Test/Unit/Plugin/ProductUpdateTest.php
+++ b/Test/Unit/Plugin/ProductUpdateTest.php
@@ -39,7 +39,9 @@ declare(strict_types=1);
 
 namespace Nosto\Tagging\Test\Unit\Plugin;
 
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product as MagentoResourceProduct;
 use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
 use Magento\Framework\Indexer\IndexerInterface;
@@ -272,6 +274,96 @@ class ProductUpdateTest extends TestCase
                 return 'saved';
             },
             $this->productMock
+        );
+        $this->runCommitCallbacks();
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductUpdate::aroundSave()
+     */
+    public function testAroundSaveQueuesDiscontinueWhenProductBecomesNotIndividuallyVisible(): void
+    {
+        $this->indexerMock->method('isScheduled')->willReturn(true);
+
+        $this->productMock->method('getOrigData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_BOTH);
+        $this->productMock->method('getData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_NOT_VISIBLE);
+
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->willReturn(['2']);
+
+        $store = $this->createMock(Store::class);
+        $this->nostoHelperScopeMock->method('getWebsite')
+            ->with(2)
+            ->willReturn($this->mockStore([$store]));
+
+        $this->productUpdateServiceMock->expects($this->once())
+            ->method('addIdsToDeleteMessageQueue')
+            ->with([self::PRODUCT_ID], $store);
+
+        $result = $this->plugin->aroundSave(
+            $this->productResourceMock,
+            function () {
+                return 'saved';
+            },
+            $this->productMock
+        );
+
+        $this->assertSame('saved', $result);
+        $this->runCommitCallbacks();
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductUpdate::aroundSave()
+     */
+    public function testAroundSaveDoesNotQueueDiscontinueWhenVisibilityIsUnchanged(): void
+    {
+        $this->indexerMock->method('isScheduled')->willReturn(true);
+
+        $this->productMock->method('getOrigData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_BOTH);
+        $this->productMock->method('getData')
+            ->with(ProductInterface::VISIBILITY)
+            ->willReturn(Visibility::VISIBILITY_BOTH);
+
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->willReturn(['2']);
+
+        $this->productUpdateServiceMock->expects($this->never())
+            ->method('addIdsToDeleteMessageQueue');
+
+        $this->plugin->aroundSave(
+            $this->productResourceMock,
+            function () {
+                return 'saved';
+            },
+            $this->productMock
+        );
+        $this->runCommitCallbacks();
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductUpdate::aroundSave()
+     */
+    public function testAroundSaveDoesNotQueueDiscontinueForVisibilityOnNewProducts(): void
+    {
+        $this->indexerMock->method('isScheduled')->willReturn(true);
+
+        $newProduct = $this->createMock(Product::class);
+        $newProduct->method('getId')->willReturn(null);
+        $newProduct->expects($this->never())->method('getOrigData');
+
+        $this->productUpdateServiceMock->expects($this->never())
+            ->method('addIdsToDeleteMessageQueue');
+
+        $this->plugin->aroundSave(
+            $this->productResourceMock,
+            function () {
+                return 'saved';
+            },
+            $newProduct
         );
         $this->runCommitCallbacks();
     }

--- a/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
+++ b/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
@@ -39,7 +39,6 @@ declare(strict_types=1);
 
 namespace Nosto\Tagging\Test\Unit\Plugin;
 
-use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Action as ProductAction;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
@@ -47,8 +46,7 @@ use Magento\Store\Model\Store;
 use Magento\Store\Model\Website;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
-use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
-use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
+use Nosto\Tagging\Model\Product\VisibilityResolver;
 use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
 use Nosto\Tagging\Plugin\ProductVisibilityUpdate;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -62,11 +60,8 @@ class ProductVisibilityUpdateTest extends TestCase
     /** @var ProductAction|MockObject */
     private MockObject $productActionMock;
 
-    /** @var CollectionBuilder|MockObject */
-    private MockObject $productCollectionBuilderMock;
-
-    /** @var ProductCollection|MockObject */
-    private MockObject $productCollectionMock;
+    /** @var VisibilityResolver|MockObject */
+    private MockObject $visibilityResolverMock;
 
     /** @var ProductStoreLink|MockObject */
     private MockObject $productStoreLinkMock;
@@ -80,37 +75,18 @@ class ProductVisibilityUpdateTest extends TestCase
     protected function setUp(): void
     {
         $this->productActionMock = $this->createMock(ProductAction::class);
-        $this->productCollectionMock = $this->createMock(ProductCollection::class);
-
-        $this->productCollectionBuilderMock = $this->createMock(CollectionBuilder::class);
-        $this->productCollectionBuilderMock->method('withStore')->willReturnSelf();
-        $this->productCollectionBuilderMock->method('withIds')->willReturnSelf();
-        $this->productCollectionBuilderMock->method('build')->willReturn($this->productCollectionMock);
-
+        $this->visibilityResolverMock = $this->createMock(VisibilityResolver::class);
         $this->productStoreLinkMock = $this->createMock(ProductStoreLink::class);
         $this->nostoHelperScopeMock = $this->createMock(NostoHelperScope::class);
         $this->productUpdateServiceMock = $this->createMock(ProductUpdateService::class);
 
         $this->plugin = new ProductVisibilityUpdate(
-            $this->productCollectionBuilderMock,
+            $this->visibilityResolverMock,
             $this->productStoreLinkMock,
             $this->nostoHelperScopeMock,
             $this->productUpdateServiceMock,
             $this->createMock(NostoLogger::class)
         );
-    }
-
-    /**
-     * @param int $id
-     * @param int $visibility
-     * @return Product|MockObject
-     */
-    private function mockProductItem(int $id, int $visibility): MockObject
-    {
-        $product = $this->createMock(Product::class);
-        $product->method('getId')->willReturn($id);
-        $product->method('getVisibility')->willReturn($visibility);
-        return $product;
     }
 
     /**
@@ -129,13 +105,13 @@ class ProductVisibilityUpdateTest extends TestCase
      */
     public function testMassHideAtSpecificStoreQueuesDiscontinueOnlyForThatStore(): void
     {
-        $this->productCollectionMock->method('getItems')->willReturn([
-            $this->mockProductItem(11, Visibility::VISIBILITY_BOTH),
-            $this->mockProductItem(22, Visibility::VISIBILITY_NOT_VISIBLE),
-        ]);
-
         $store = $this->createMock(Store::class);
         $this->nostoHelperScopeMock->method('getStore')->with(5)->willReturn($store);
+
+        $this->visibilityResolverMock->expects($this->once())
+            ->method('getIndividuallyVisibleProductIds')
+            ->with([11, 22], $store)
+            ->willReturn([11]);
 
         $this->productUpdateServiceMock->expects($this->once())
             ->method('addIdsToDeleteMessageQueue')
@@ -159,16 +135,19 @@ class ProductVisibilityUpdateTest extends TestCase
      */
     public function testMassHideAtDefaultScopeQueuesDiscontinueAcrossAllAssignedStores(): void
     {
-        $this->productCollectionMock->method('getItems')->willReturn([
-            $this->mockProductItem(11, Visibility::VISIBILITY_BOTH),
-        ]);
-        $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($this->createMock(Store::class));
-
-        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->with(11)->willReturn(['2']);
-
+        $defaultStore = $this->createMock(Store::class);
         $storeA = $this->createMock(Store::class);
         $storeB = $this->createMock(Store::class);
+
+        $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($defaultStore);
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->with(11)->willReturn(['2']);
         $this->nostoHelperScopeMock->method('getWebsite')->with(2)->willReturn($this->mockWebsite([$storeA, $storeB]));
+
+        // Neither store has its own override, so both now resolve to hidden.
+        $this->visibilityResolverMock->method('getIndividuallyVisibleProductIds')
+            ->willReturnCallback(function (array $ids, Store $store) use ($defaultStore) {
+                return $store === $defaultStore ? [11] : [];
+            });
 
         $deleteQueueCalls = [];
         $this->productUpdateServiceMock->expects($this->exactly(2))
@@ -194,9 +173,47 @@ class ProductVisibilityUpdateTest extends TestCase
     /**
      * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
      */
+    public function testMassHideAtDefaultScopeSkipsStoresWithTheirOwnOverride(): void
+    {
+        $defaultStore = $this->createMock(Store::class);
+        $storeA = $this->createMock(Store::class);
+        $storeB = $this->createMock(Store::class);
+
+        $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($defaultStore);
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->with(11)->willReturn(['2']);
+        $this->nostoHelperScopeMock->method('getWebsite')->with(2)->willReturn($this->mockWebsite([$storeA, $storeB]));
+
+        // Store B has its own visibility override that keeps it visible, so it must
+        // not be discontinued just because the default value changed.
+        $this->visibilityResolverMock->method('getIndividuallyVisibleProductIds')
+            ->willReturnCallback(function (array $ids, Store $store) use ($defaultStore, $storeB) {
+                if ($store === $defaultStore) {
+                    return [11];
+                }
+                return $store === $storeB ? [11] : [];
+            });
+
+        $this->productUpdateServiceMock->expects($this->once())
+            ->method('addIdsToDeleteMessageQueue')
+            ->with([11], $storeA);
+
+        $this->plugin->aroundUpdateAttributes(
+            $this->productActionMock,
+            function () {
+                return 'updated';
+            },
+            [11],
+            ['visibility' => Visibility::VISIBILITY_NOT_VISIBLE],
+            0
+        );
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
+     */
     public function testMassUpdateOfUnrelatedAttributeDoesNotQueueDiscontinue(): void
     {
-        $this->productCollectionBuilderMock->expects($this->never())->method('withIds');
+        $this->visibilityResolverMock->expects($this->never())->method('getIndividuallyVisibleProductIds');
         $this->productUpdateServiceMock->expects($this->never())->method('addIdsToDeleteMessageQueue');
 
         $result = $this->plugin->aroundUpdateAttributes(
@@ -217,10 +234,8 @@ class ProductVisibilityUpdateTest extends TestCase
      */
     public function testMassHideOfAlreadyHiddenProductsDoesNotQueueDiscontinue(): void
     {
-        $this->productCollectionMock->method('getItems')->willReturn([
-            $this->mockProductItem(11, Visibility::VISIBILITY_NOT_VISIBLE),
-        ]);
         $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($this->createMock(Store::class));
+        $this->visibilityResolverMock->method('getIndividuallyVisibleProductIds')->willReturn([]);
 
         $this->productUpdateServiceMock->expects($this->never())->method('addIdsToDeleteMessageQueue');
 
@@ -240,7 +255,7 @@ class ProductVisibilityUpdateTest extends TestCase
      */
     public function testEmptyProductIdsDoesNothing(): void
     {
-        $this->productCollectionBuilderMock->expects($this->never())->method('withIds');
+        $this->visibilityResolverMock->expects($this->never())->method('getIndividuallyVisibleProductIds');
         $this->productUpdateServiceMock->expects($this->never())->method('addIdsToDeleteMessageQueue');
 
         $this->plugin->aroundUpdateAttributes(

--- a/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
+++ b/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
@@ -41,12 +41,12 @@ namespace Nosto\Tagging\Test\Unit\Plugin;
 
 use Magento\Catalog\Model\Product\Action as ProductAction;
 use Magento\Catalog\Model\Product\Visibility;
-use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\Website;
 use Nosto\Tagging\Helper\Scope as NostoHelperScope;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\Product\VisibilityResolver;
+use Nosto\Tagging\Model\ResourceModel\Product\WebsiteLink;
 use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
 use Nosto\Tagging\Plugin\ProductVisibilityUpdate;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -63,8 +63,8 @@ class ProductVisibilityUpdateTest extends TestCase
     /** @var VisibilityResolver|MockObject */
     private MockObject $visibilityResolverMock;
 
-    /** @var ProductStoreLink|MockObject */
-    private MockObject $productStoreLinkMock;
+    /** @var WebsiteLink|MockObject */
+    private MockObject $productWebsiteLinkMock;
 
     /** @var NostoHelperScope|MockObject */
     private MockObject $nostoHelperScopeMock;
@@ -76,13 +76,13 @@ class ProductVisibilityUpdateTest extends TestCase
     {
         $this->productActionMock = $this->createMock(ProductAction::class);
         $this->visibilityResolverMock = $this->createMock(VisibilityResolver::class);
-        $this->productStoreLinkMock = $this->createMock(ProductStoreLink::class);
+        $this->productWebsiteLinkMock = $this->createMock(WebsiteLink::class);
         $this->nostoHelperScopeMock = $this->createMock(NostoHelperScope::class);
         $this->productUpdateServiceMock = $this->createMock(ProductUpdateService::class);
 
         $this->plugin = new ProductVisibilityUpdate(
             $this->visibilityResolverMock,
-            $this->productStoreLinkMock,
+            $this->productWebsiteLinkMock,
             $this->nostoHelperScopeMock,
             $this->productUpdateServiceMock,
             $this->createMock(NostoLogger::class)
@@ -138,9 +138,14 @@ class ProductVisibilityUpdateTest extends TestCase
         $defaultStore = $this->createMock(Store::class);
         $storeA = $this->createMock(Store::class);
         $storeB = $this->createMock(Store::class);
+        $storeA->method('getId')->willReturn(1);
+        $storeB->method('getId')->willReturn(2);
 
         $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($defaultStore);
-        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->with(11)->willReturn(['2']);
+        $this->productWebsiteLinkMock->expects($this->once())
+            ->method('getWebsiteIdsByProductIds')
+            ->with([11])
+            ->willReturn([11 => [2]]);
         $this->nostoHelperScopeMock->method('getWebsite')->with(2)->willReturn($this->mockWebsite([$storeA, $storeB]));
 
         // Neither store has its own override, so both now resolve to hidden.
@@ -178,9 +183,11 @@ class ProductVisibilityUpdateTest extends TestCase
         $defaultStore = $this->createMock(Store::class);
         $storeA = $this->createMock(Store::class);
         $storeB = $this->createMock(Store::class);
+        $storeA->method('getId')->willReturn(1);
+        $storeB->method('getId')->willReturn(2);
 
         $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($defaultStore);
-        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->with(11)->willReturn(['2']);
+        $this->productWebsiteLinkMock->method('getWebsiteIdsByProductIds')->with([11])->willReturn([11 => [2]]);
         $this->nostoHelperScopeMock->method('getWebsite')->with(2)->willReturn($this->mockWebsite([$storeA, $storeB]));
 
         // Store B has its own visibility override that keeps it visible, so it must
@@ -203,6 +210,51 @@ class ProductVisibilityUpdateTest extends TestCase
                 return 'updated';
             },
             [11],
+            ['visibility' => Visibility::VISIBILITY_NOT_VISIBLE],
+            0
+        );
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
+     */
+    public function testMassHideAtDefaultScopeBatchesMultipleProductsIntoOneQueryPerStore(): void
+    {
+        $defaultStore = $this->createMock(Store::class);
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(1);
+
+        $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($defaultStore);
+
+        // All three products share the same website/store.
+        $this->productWebsiteLinkMock->expects($this->once())
+            ->method('getWebsiteIdsByProductIds')
+            ->with([11, 22, 33])
+            ->willReturn([11 => [2], 22 => [2], 33 => [2]]);
+        $this->nostoHelperScopeMock->method('getWebsite')->with(2)->willReturn($this->mockWebsite([$store]));
+
+        // A single batched call for the whole group, not one call per product.
+        $this->visibilityResolverMock->expects($this->exactly(2))
+            ->method('getIndividuallyVisibleProductIds')
+            ->willReturnCallback(function (array $ids, Store $s) use ($defaultStore, $store) {
+                if ($s === $defaultStore) {
+                    return [11, 22, 33];
+                }
+                $this->assertSame($store, $s);
+                $this->assertSame([11, 22, 33], $ids);
+                return [];
+            });
+
+        $this->productUpdateServiceMock->expects($this->once())
+            ->method('addIdsToDeleteMessageQueue')
+            ->with([11, 22, 33], $store);
+
+        $this->plugin->aroundUpdateAttributes(
+            $this->productActionMock,
+            function () {
+                return 'updated';
+            },
+            [11, 22, 33],
             ['visibility' => Visibility::VISIBILITY_NOT_VISIBLE],
             0
         );
@@ -237,6 +289,7 @@ class ProductVisibilityUpdateTest extends TestCase
         $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($this->createMock(Store::class));
         $this->visibilityResolverMock->method('getIndividuallyVisibleProductIds')->willReturn([]);
 
+        $this->productWebsiteLinkMock->expects($this->never())->method('getWebsiteIdsByProductIds');
         $this->productUpdateServiceMock->expects($this->never())->method('addIdsToDeleteMessageQueue');
 
         $this->plugin->aroundUpdateAttributes(

--- a/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
+++ b/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
@@ -72,6 +72,9 @@ class ProductVisibilityUpdateTest extends TestCase
     /** @var ProductUpdateService|MockObject */
     private MockObject $productUpdateServiceMock;
 
+    /** @var NostoLogger|MockObject */
+    private MockObject $loggerMock;
+
     protected function setUp(): void
     {
         $this->productActionMock = $this->createMock(ProductAction::class);
@@ -79,13 +82,14 @@ class ProductVisibilityUpdateTest extends TestCase
         $this->productWebsiteLinkMock = $this->createMock(WebsiteLink::class);
         $this->nostoHelperScopeMock = $this->createMock(NostoHelperScope::class);
         $this->productUpdateServiceMock = $this->createMock(ProductUpdateService::class);
+        $this->loggerMock = $this->createMock(NostoLogger::class);
 
         $this->plugin = new ProductVisibilityUpdate(
             $this->visibilityResolverMock,
             $this->productWebsiteLinkMock,
             $this->nostoHelperScopeMock,
             $this->productUpdateServiceMock,
-            $this->createMock(NostoLogger::class)
+            $this->loggerMock
         );
     }
 
@@ -116,6 +120,7 @@ class ProductVisibilityUpdateTest extends TestCase
         $this->productUpdateServiceMock->expects($this->once())
             ->method('addIdsToDeleteMessageQueue')
             ->with([11], $store);
+        $this->loggerMock->expects($this->once())->method('debug');
 
         $result = $this->plugin->aroundUpdateAttributes(
             $this->productActionMock,
@@ -203,6 +208,7 @@ class ProductVisibilityUpdateTest extends TestCase
         $this->productUpdateServiceMock->expects($this->once())
             ->method('addIdsToDeleteMessageQueue')
             ->with([11], $storeA);
+        $this->loggerMock->expects($this->once())->method('debug');
 
         $this->plugin->aroundUpdateAttributes(
             $this->productActionMock,

--- a/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
+++ b/Test/Unit/Plugin/ProductVisibilityUpdateTest.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Copyright (c) 2026, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2026 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nosto\Tagging\Test\Unit\Plugin;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Action as ProductAction;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\Website\Link as ProductStoreLink;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\Website;
+use Nosto\Tagging\Helper\Scope as NostoHelperScope;
+use Nosto\Tagging\Logger\Logger as NostoLogger;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\Collection as ProductCollection;
+use Nosto\Tagging\Model\ResourceModel\Magento\Product\CollectionBuilder;
+use Nosto\Tagging\Model\Service\Update\ProductUpdateService;
+use Nosto\Tagging\Plugin\ProductVisibilityUpdate;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ProductVisibilityUpdateTest extends TestCase
+{
+    /** @var ProductVisibilityUpdate */
+    private ProductVisibilityUpdate $plugin;
+
+    /** @var ProductAction|MockObject */
+    private MockObject $productActionMock;
+
+    /** @var CollectionBuilder|MockObject */
+    private MockObject $productCollectionBuilderMock;
+
+    /** @var ProductCollection|MockObject */
+    private MockObject $productCollectionMock;
+
+    /** @var ProductStoreLink|MockObject */
+    private MockObject $productStoreLinkMock;
+
+    /** @var NostoHelperScope|MockObject */
+    private MockObject $nostoHelperScopeMock;
+
+    /** @var ProductUpdateService|MockObject */
+    private MockObject $productUpdateServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->productActionMock = $this->createMock(ProductAction::class);
+        $this->productCollectionMock = $this->createMock(ProductCollection::class);
+
+        $this->productCollectionBuilderMock = $this->createMock(CollectionBuilder::class);
+        $this->productCollectionBuilderMock->method('withStore')->willReturnSelf();
+        $this->productCollectionBuilderMock->method('withIds')->willReturnSelf();
+        $this->productCollectionBuilderMock->method('build')->willReturn($this->productCollectionMock);
+
+        $this->productStoreLinkMock = $this->createMock(ProductStoreLink::class);
+        $this->nostoHelperScopeMock = $this->createMock(NostoHelperScope::class);
+        $this->productUpdateServiceMock = $this->createMock(ProductUpdateService::class);
+
+        $this->plugin = new ProductVisibilityUpdate(
+            $this->productCollectionBuilderMock,
+            $this->productStoreLinkMock,
+            $this->nostoHelperScopeMock,
+            $this->productUpdateServiceMock,
+            $this->createMock(NostoLogger::class)
+        );
+    }
+
+    /**
+     * @param int $id
+     * @param int $visibility
+     * @return Product|MockObject
+     */
+    private function mockProductItem(int $id, int $visibility): MockObject
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getId')->willReturn($id);
+        $product->method('getVisibility')->willReturn($visibility);
+        return $product;
+    }
+
+    /**
+     * @param Store[] $stores
+     * @return Website|MockObject
+     */
+    private function mockWebsite(array $stores): MockObject
+    {
+        $website = $this->createMock(Website::class);
+        $website->method('getStores')->willReturn($stores);
+        return $website;
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
+     */
+    public function testMassHideAtSpecificStoreQueuesDiscontinueOnlyForThatStore(): void
+    {
+        $this->productCollectionMock->method('getItems')->willReturn([
+            $this->mockProductItem(11, Visibility::VISIBILITY_BOTH),
+            $this->mockProductItem(22, Visibility::VISIBILITY_NOT_VISIBLE),
+        ]);
+
+        $store = $this->createMock(Store::class);
+        $this->nostoHelperScopeMock->method('getStore')->with(5)->willReturn($store);
+
+        $this->productUpdateServiceMock->expects($this->once())
+            ->method('addIdsToDeleteMessageQueue')
+            ->with([11], $store);
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->productActionMock,
+            function () {
+                return 'updated';
+            },
+            [11, 22],
+            ['visibility' => Visibility::VISIBILITY_NOT_VISIBLE],
+            5
+        );
+
+        $this->assertSame('updated', $result);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
+     */
+    public function testMassHideAtDefaultScopeQueuesDiscontinueAcrossAllAssignedStores(): void
+    {
+        $this->productCollectionMock->method('getItems')->willReturn([
+            $this->mockProductItem(11, Visibility::VISIBILITY_BOTH),
+        ]);
+        $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($this->createMock(Store::class));
+
+        $this->productStoreLinkMock->method('getWebsiteIdsByProductId')->with(11)->willReturn(['2']);
+
+        $storeA = $this->createMock(Store::class);
+        $storeB = $this->createMock(Store::class);
+        $this->nostoHelperScopeMock->method('getWebsite')->with(2)->willReturn($this->mockWebsite([$storeA, $storeB]));
+
+        $deleteQueueCalls = [];
+        $this->productUpdateServiceMock->expects($this->exactly(2))
+            ->method('addIdsToDeleteMessageQueue')
+            ->willReturnCallback(function (array $ids, $store) use (&$deleteQueueCalls) {
+                $deleteQueueCalls[] = [$ids, $store];
+            });
+
+        $this->plugin->aroundUpdateAttributes(
+            $this->productActionMock,
+            function () {
+                return 'updated';
+            },
+            [11],
+            ['visibility' => Visibility::VISIBILITY_NOT_VISIBLE],
+            0
+        );
+
+        $this->assertSame([[11], $storeA], $deleteQueueCalls[0]);
+        $this->assertSame([[11], $storeB], $deleteQueueCalls[1]);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
+     */
+    public function testMassUpdateOfUnrelatedAttributeDoesNotQueueDiscontinue(): void
+    {
+        $this->productCollectionBuilderMock->expects($this->never())->method('withIds');
+        $this->productUpdateServiceMock->expects($this->never())->method('addIdsToDeleteMessageQueue');
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->productActionMock,
+            function () {
+                return 'updated';
+            },
+            [11, 22],
+            ['status' => 2],
+            0
+        );
+
+        $this->assertSame('updated', $result);
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
+     */
+    public function testMassHideOfAlreadyHiddenProductsDoesNotQueueDiscontinue(): void
+    {
+        $this->productCollectionMock->method('getItems')->willReturn([
+            $this->mockProductItem(11, Visibility::VISIBILITY_NOT_VISIBLE),
+        ]);
+        $this->nostoHelperScopeMock->method('getStore')->with(0)->willReturn($this->createMock(Store::class));
+
+        $this->productUpdateServiceMock->expects($this->never())->method('addIdsToDeleteMessageQueue');
+
+        $this->plugin->aroundUpdateAttributes(
+            $this->productActionMock,
+            function () {
+                return 'updated';
+            },
+            [11],
+            ['visibility' => Visibility::VISIBILITY_NOT_VISIBLE],
+            0
+        );
+    }
+
+    /**
+     * @covers \Nosto\Tagging\Plugin\ProductVisibilityUpdate::aroundUpdateAttributes()
+     */
+    public function testEmptyProductIdsDoesNothing(): void
+    {
+        $this->productCollectionBuilderMock->expects($this->never())->method('withIds');
+        $this->productUpdateServiceMock->expects($this->never())->method('addIdsToDeleteMessageQueue');
+
+        $this->plugin->aroundUpdateAttributes(
+            $this->productActionMock,
+            function () {
+                return 'updated';
+            },
+            [],
+            ['visibility' => Visibility::VISIBILITY_NOT_VISIBLE],
+            0
+        );
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -57,6 +57,7 @@
     </type>
     <type name="Magento\Catalog\Model\Product\Action">
         <plugin name="nostoProductStoreUpdate" type="Nosto\Tagging\Plugin\ProductStoreUpdate"/>
+        <plugin name="nostoProductVisibilityUpdate" type="Nosto\Tagging\Plugin\ProductVisibilityUpdate"/>
     </type>
     <type name="Magento\Catalog\Model\ResourceModel\Category">
         <plugin name="nostoCategoryObserverUpdate" type="Nosto\Tagging\Plugin\CategoryUpdate"/>


### PR DESCRIPTION
[NS-14429](https://nostosolutions.atlassian.net/browse/NS-14429)

### Problem
When a product's visibility changes to "Not Visible Individually", Nosto was never told to remove it. The product just silently stopped being considered for future syncs, but nothing sent an explicit discontinue signal, so it stayed live in Nosto search/recommendations indefinitely, orphaned.

### Solution
Two paths needed covering, since visibility changes reach Magento through two different mechanisms:

- **Single-product save** (admin form, API)- `Plugin/ProductUpdate::aroundSave` now detects a transition to "Not Visible Individually" and queues a discontinue message for the product's current stores.
- **Product grid mass "Update Attributes"**- this bypasses the normal save path entirely via a separate resource class, so a dedicated plugin (`Plugin/ProductVisibilityUpdate`) was added to catch it too. It checks each product's visibility before the bulk update and only discontinues the ones that actually go from visible to hidden.

### How Has This Been Tested?
Unit tests cover both plugins: single-product visibility change, mass "Update Attributes" at a specific store view and at "All Store Views", and the no-op cases (visibility unchanged, already hidden, new products).

[NS-14429]: https://nostosolutions.atlassian.net/browse/NS-14429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ