### PR TITLE
Hyva template fixes

### DIFF
--- a/view/frontend/templates/hyva/tagging-provider.phtml
+++ b/view/frontend/templates/hyva/tagging-provider.phtml
@@ -38,18 +38,18 @@
  * @var \Nosto\Tagging\Block\TaggingProvider $block
  * @var Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-$taggingConfig = $block->getTaggingConfig();
+$taggingConfig = $block->escapeJsQuote($block->getTaggingConfigForJs());
 ?>
 
-<!-- Hyva Theme with Alpine.js -->
+    <!-- Hyva Theme with Alpine.js -->
 <?php if ($block->isNostoEnabled()):
 
     $script = <<<script
         document.addEventListener('DOMContentLoaded', function() {
-            window.initNostoTaggingProviders(<?= $block->escapeJsQuote($block->getTaggingConfigForJs()) ?>);
+            window.initNostoTaggingProviders($taggingConfig);
         });
     script;
 
- /* @noEscape */ $secureRenderer->renderTag('script', [], $script, false);
+    echo /* @noEscape */ $secureRenderer->renderTag('script', [], $script, false);
 
 endif; ?>

--- a/view/frontend/templates/hyva/tagging-provider.phtml
+++ b/view/frontend/templates/hyva/tagging-provider.phtml
@@ -38,7 +38,7 @@
  * @var \Nosto\Tagging\Block\TaggingProvider $block
  * @var Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-$taggingConfig = $block->escapeJsQuote($block->getTaggingConfigForJs());
+$taggingConfig = $block->getTaggingConfigForJs();
 ?>
 
     <!-- Hyva Theme with Alpine.js -->

--- a/view/frontend/templates/hyva/variation.phtml
+++ b/view/frontend/templates/hyva/variation.phtml
@@ -116,5 +116,5 @@ $variationId = $block->getVariationId();
     });
     script;
 
- /* @noEscape */ $secureRenderer->renderTag('script', [], $script, false);
+ echo /* @noEscape */ $secureRenderer->renderTag('script', [], $script, false);
 endif; ?>


### PR DESCRIPTION
This fixes two instances of hyva templates not outputting their script tags and/or having PHP-short-tags inside HEREDOCs (which don't work).

## Description

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
